### PR TITLE
Harden sync IO limits and stabilize recovery tests

### DIFF
--- a/src/net/message_channels.rs
+++ b/src/net/message_channels.rs
@@ -5,7 +5,7 @@ use tokio::sync::mpsc::{Receiver, Sender};
 
 use super::{
     io::SyncIO,
-    message_io::{read_message_opt, send_message, send_zero_message},
+    message_io::{read_message_opt_with_oversized_id, send_message, send_zero_message},
 };
 
 #[derive(Clone, Debug)]
@@ -13,6 +13,7 @@ pub struct NetIoSettings {
     pub process_timeout: Duration,
     pub message_timeout: Duration,
     pub max_message_size_bytes: usize,
+    pub max_state_message_size: Option<usize>,
 }
 
 impl Default for NetIoSettings {
@@ -21,6 +22,7 @@ impl Default for NetIoSettings {
             process_timeout: Duration::from_secs(2),
             message_timeout: Duration::from_secs(12),
             max_message_size_bytes: 8 * 1024 * 1024,
+            max_state_message_size: None,
         }
     }
 }
@@ -29,6 +31,7 @@ pub struct ReadChannel<I: SyncIO, M: MessageEncoding> {
     pub input: I::Read,
     pub output: Sender<M>,
     pub settings: NetIoSettings,
+    pub oversized_message_id: Option<(u16, Option<usize>)>,
 }
 
 pub struct WriteChannel<I: SyncIO, M: MessageEncoding> {
@@ -45,12 +48,13 @@ impl<I: SyncIO, M: MessageEncoding + Send + Sync + 'static> ReadChannel<I, M> {
             tokio::task::yield_now().await;
 
             let read_opt_res = tokio::select! {
-                read_opt_res = read_message_opt::<M, _>(
+                read_opt_res = read_message_opt_with_oversized_id::<M, _>(
                     &mut buffer,
                     &mut self.input,
                     self.settings.process_timeout,
                     Some(self.settings.message_timeout),
                     self.settings.max_message_size_bytes,
+                    self.oversized_message_id,
                 ) => read_opt_res,
                 _ = self.output.closed() => {
                     tracing::info!("output closed, stopping read");

--- a/src/net/message_channels.rs
+++ b/src/net/message_channels.rs
@@ -12,6 +12,7 @@ use super::{
 pub struct NetIoSettings {
     pub process_timeout: Duration,
     pub message_timeout: Duration,
+    pub max_message_size_bytes: usize,
 }
 
 impl Default for NetIoSettings {
@@ -19,6 +20,7 @@ impl Default for NetIoSettings {
         Self {
             process_timeout: Duration::from_secs(2),
             message_timeout: Duration::from_secs(12),
+            max_message_size_bytes: 8 * 1024 * 1024,
         }
     }
 }
@@ -48,6 +50,7 @@ impl<I: SyncIO, M: MessageEncoding + Send + Sync + 'static> ReadChannel<I, M> {
                     &mut self.input,
                     self.settings.process_timeout,
                     Some(self.settings.message_timeout),
+                    self.settings.max_message_size_bytes,
                 ) => read_opt_res,
                 _ = self.output.closed() => {
                     tracing::info!("output closed, stopping read");

--- a/src/net/message_io.rs
+++ b/src/net/message_io.rs
@@ -11,7 +11,14 @@ pub async fn read_message<M: MessageEncoding, R: AsyncRead + Unpin>(
     read: &mut R,
     progress_timeout: Duration,
 ) -> Result<Option<M>, ReadMessageError> {
-    read_message_opt(buffer, read, progress_timeout, None, MessageSizeHeader::MAX as usize).await
+    read_message_opt(
+        buffer,
+        read,
+        progress_timeout,
+        None,
+        MessageSizeHeader::MAX as usize,
+    )
+    .await
 }
 
 pub async fn read_message_opt<M: MessageEncoding, R: AsyncRead + Unpin>(
@@ -21,9 +28,36 @@ pub async fn read_message_opt<M: MessageEncoding, R: AsyncRead + Unpin>(
     recv_timeout: Option<Duration>,
     max_message_size: usize,
 ) -> Result<Option<M>, ReadMessageError> {
+    read_message_opt_with_oversized_id(
+        buffer,
+        read,
+        progress_timeout,
+        recv_timeout,
+        max_message_size,
+        None,
+    )
+    .await
+}
+
+pub async fn read_message_opt_with_oversized_id<M: MessageEncoding, R: AsyncRead + Unpin>(
+    buffer: &mut Vec<u8>,
+    read: &mut R,
+    progress_timeout: Duration,
+    recv_timeout: Option<Duration>,
+    max_message_size: usize,
+    oversized_message_id: Option<(u16, Option<usize>)>,
+) -> Result<Option<M>, ReadMessageError> {
     let _assert = black_box(M::_ASSERT);
 
-    if !read_message_to_vec(buffer, read, progress_timeout, recv_timeout, max_message_size).await?
+    if !read_message_to_vec(
+        buffer,
+        read,
+        progress_timeout,
+        recv_timeout,
+        max_message_size,
+        oversized_message_id,
+    )
+    .await?
     {
         return Ok(None);
     }
@@ -39,6 +73,7 @@ pub async fn read_message_to_vec<R: AsyncRead + Unpin>(
     progress_timeout: Duration,
     recv_timeout: Option<Duration>,
     max_message_size: usize,
+    oversized_message_id: Option<(u16, Option<usize>)>,
 ) -> Result<bool, ReadMessageError> {
     let mut len_bytes = [0u8; MESSAGE_HEADER_SIZE];
 
@@ -58,14 +93,42 @@ pub async fn read_message_to_vec<R: AsyncRead + Unpin>(
         return Ok(false);
     }
     if max_message_size < msg_len {
-        return Err(ReadMessageError::MessageTooLarge(msg_len));
+        let Some((allowed_id, max_oversized_message_size)) = oversized_message_id else {
+            return Err(ReadMessageError::MessageTooLarge(msg_len));
+        };
+
+        let message_id_size = std::mem::size_of::<u16>();
+        if msg_len < message_id_size {
+            return Err(ReadMessageError::MessageTooLarge(msg_len));
+        }
+
+        let mut msg_id_bytes = [0u8; std::mem::size_of::<u16>()];
+        read_message_bytes(read, progress_timeout, &mut msg_id_bytes).await?;
+        let msg_id = u16::from_be_bytes(msg_id_bytes);
+        if msg_id != allowed_id || max_oversized_message_size.is_some_and(|max| max < msg_len) {
+            return Err(ReadMessageError::MessageTooLarge(msg_len));
+        }
+
+        buffer.clear();
+        buffer.resize(msg_len, 0u8);
+        buffer[..message_id_size].copy_from_slice(&msg_id_bytes);
+        read_message_bytes(read, progress_timeout, &mut buffer[message_id_size..]).await?;
+        return Ok(true);
     }
 
     buffer.clear();
     buffer.resize(msg_len, 0u8);
+    read_message_bytes(read, progress_timeout, buffer).await?;
+    Ok(true)
+}
 
+async fn read_message_bytes<R: AsyncRead + Unpin>(
+    read: &mut R,
+    progress_timeout: Duration,
+    buffer: &mut [u8],
+) -> Result<(), ReadMessageError> {
     let mut bytes_read = 0;
-    while bytes_read < msg_len {
+    while bytes_read < buffer.len() {
         match tokio::time::timeout(progress_timeout, read.read(&mut buffer[bytes_read..])).await {
             Err(_) => return Err(ReadMessageError::MessageReadTimeout),
             Ok(Err(error)) => return Err(ReadMessageError::MessageReadError(error)),
@@ -76,7 +139,7 @@ pub async fn read_message_to_vec<R: AsyncRead + Unpin>(
         }
     }
 
-    Ok(true)
+    Ok(())
 }
 
 #[derive(Debug)]
@@ -314,6 +377,73 @@ mod test {
             Duration::from_secs(1),
             Some(Duration::from_secs(2)),
             64,
+        )
+        .await
+        .unwrap_err();
+
+        assert!(matches!(err, ReadMessageError::MessageTooLarge(128)));
+    }
+
+    #[tokio::test]
+    async fn message_io_allows_unbounded_oversized_message_id_test() {
+        let (mut a, mut b) = duplex(2048);
+        a.write_all(&(128u32).to_be_bytes()).await.unwrap();
+        a.write_all(&3u16.to_be_bytes()).await.unwrap();
+        a.write_all(&[1u8; 126]).await.unwrap();
+
+        let mut buffer = Vec::new();
+        let read = read_message_to_vec(
+            &mut buffer,
+            &mut b,
+            Duration::from_secs(1),
+            Some(Duration::from_secs(2)),
+            64,
+            Some((3, None)),
+        )
+        .await
+        .unwrap();
+
+        assert!(read);
+        assert_eq!(buffer.len(), 128);
+    }
+
+    #[tokio::test]
+    async fn message_io_rejects_bounded_oversized_message_id_test() {
+        let (mut a, mut b) = duplex(2048);
+        a.write_all(&(128u32).to_be_bytes()).await.unwrap();
+        a.write_all(&3u16.to_be_bytes()).await.unwrap();
+        a.write_all(&[1u8; 126]).await.unwrap();
+
+        let mut buffer = Vec::new();
+        let err = read_message_to_vec(
+            &mut buffer,
+            &mut b,
+            Duration::from_secs(1),
+            Some(Duration::from_secs(2)),
+            64,
+            Some((3, Some(100))),
+        )
+        .await
+        .unwrap_err();
+
+        assert!(matches!(err, ReadMessageError::MessageTooLarge(128)));
+    }
+
+    #[tokio::test]
+    async fn message_io_rejects_wrong_oversized_message_id_test() {
+        let (mut a, mut b) = duplex(2048);
+        a.write_all(&(128u32).to_be_bytes()).await.unwrap();
+        a.write_all(&4u16.to_be_bytes()).await.unwrap();
+        a.write_all(&[1u8; 126]).await.unwrap();
+
+        let mut buffer = Vec::new();
+        let err = read_message_to_vec(
+            &mut buffer,
+            &mut b,
+            Duration::from_secs(1),
+            Some(Duration::from_secs(2)),
+            64,
+            Some((3, None)),
         )
         .await
         .unwrap_err();

--- a/src/net/message_io.rs
+++ b/src/net/message_io.rs
@@ -11,7 +11,7 @@ pub async fn read_message<M: MessageEncoding, R: AsyncRead + Unpin>(
     read: &mut R,
     progress_timeout: Duration,
 ) -> Result<Option<M>, ReadMessageError> {
-    read_message_opt(buffer, read, progress_timeout, None).await
+    read_message_opt(buffer, read, progress_timeout, None, MessageSizeHeader::MAX as usize).await
 }
 
 pub async fn read_message_opt<M: MessageEncoding, R: AsyncRead + Unpin>(
@@ -19,10 +19,12 @@ pub async fn read_message_opt<M: MessageEncoding, R: AsyncRead + Unpin>(
     read: &mut R,
     progress_timeout: Duration,
     recv_timeout: Option<Duration>,
+    max_message_size: usize,
 ) -> Result<Option<M>, ReadMessageError> {
     let _assert = black_box(M::_ASSERT);
 
-    if !read_message_to_vec(buffer, read, progress_timeout, recv_timeout).await? {
+    if !read_message_to_vec(buffer, read, progress_timeout, recv_timeout, max_message_size).await?
+    {
         return Ok(None);
     }
 
@@ -36,6 +38,7 @@ pub async fn read_message_to_vec<R: AsyncRead + Unpin>(
     read: &mut R,
     progress_timeout: Duration,
     recv_timeout: Option<Duration>,
+    max_message_size: usize,
 ) -> Result<bool, ReadMessageError> {
     let mut len_bytes = [0u8; MESSAGE_HEADER_SIZE];
 
@@ -53,6 +56,9 @@ pub async fn read_message_to_vec<R: AsyncRead + Unpin>(
     let msg_len = MessageSizeHeader::from_be_bytes(len_bytes) as usize;
     if msg_len == 0 {
         return Ok(false);
+    }
+    if max_message_size < msg_len {
+        return Err(ReadMessageError::MessageTooLarge(msg_len));
     }
 
     buffer.clear();
@@ -77,6 +83,7 @@ pub async fn read_message_to_vec<R: AsyncRead + Unpin>(
 pub enum ReadMessageError {
     MessageReadTimeout,
     NextMessageTimeout(Duration),
+    MessageTooLarge(usize),
     SizeReadError(std::io::Error),
     MessageReadError(std::io::Error),
     EncodingError(std::io::Error),
@@ -92,6 +99,10 @@ impl From<ReadMessageError> for std::io::Error {
                     "timeout reading remaining message data",
                 )
             }
+            ReadMessageError::MessageTooLarge(len) => std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!("message size {len} exceeds configured maximum"),
+            ),
             ReadMessageError::Closed => std::io::Error::new(
                 std::io::ErrorKind::UnexpectedEof,
                 "end of file reading message",
@@ -134,18 +145,14 @@ pub async fn send_message<M: MessageEncoding, W: AsyncWrite + Unpin>(
         "M::write_to returned incorrect number of bytes"
     );
 
-    /* if static size is known, we've already written size with MAX_SIZE var */
     if let Some(size) = M::STATIC_SIZE {
         assert_eq!(
             size, bytes_written,
             "M::STATIC_SIZE does not match M::write_to"
         );
     }
-    /* write size to start of buffer */
-    else {
-        buffer[..MESSAGE_HEADER_SIZE]
-            .copy_from_slice(&(bytes_written as MessageSizeHeader).to_be_bytes());
-    }
+    buffer[..MESSAGE_HEADER_SIZE]
+        .copy_from_slice(&(bytes_written as MessageSizeHeader).to_be_bytes());
 
     /* note: send in batches with timeout to ensure connection isn't hanging and we also can
      * support sending really large messages */
@@ -219,10 +226,33 @@ pub const fn m_max_opt_list(samples: &'static [Option<usize>]) -> Option<usize> 
 mod test {
     use std::time::Duration;
 
+    use message_encoding::m_opt_sum;
     use tokio::io::duplex;
 
     use super::*;
     use crate::testing::state_tests::TestStateAction;
+
+    #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+    struct FixedMessage {
+        a: u64,
+        b: u64,
+    }
+
+    impl MessageEncoding for FixedMessage {
+        const STATIC_SIZE: Option<usize> = m_opt_sum(&[u64::STATIC_SIZE, u64::STATIC_SIZE]);
+        const MAX_SIZE: Option<usize> = Self::STATIC_SIZE;
+
+        fn write_to<T: std::io::Write>(&self, out: &mut T) -> std::io::Result<usize> {
+            Ok(self.a.write_to(out)? + self.b.write_to(out)?)
+        }
+
+        fn read_from<T: std::io::Read>(read: &mut T) -> std::io::Result<Self> {
+            Ok(Self {
+                a: MessageEncoding::read_from(read)?,
+                b: MessageEncoding::read_from(read)?,
+            })
+        }
+    }
 
     #[tokio::test]
     async fn message_io_test() {
@@ -242,9 +272,52 @@ mod test {
             &mut b,
             Duration::from_secs(1),
             Some(Duration::from_secs(2)),
+            1024,
         )
         .await
         .unwrap();
         assert_eq!(Some(send), read);
+    }
+
+    #[tokio::test]
+    async fn message_io_fixed_size_message_test() {
+        let (mut a, mut b) = duplex(2048);
+        let mut buffer = Vec::with_capacity(1024);
+
+        let send = FixedMessage { a: 7, b: 11 };
+        send_message(&mut buffer, &send, &mut a, Duration::from_secs(1))
+            .await
+            .unwrap();
+
+        let read = read_message_opt(
+            &mut buffer,
+            &mut b,
+            Duration::from_secs(1),
+            Some(Duration::from_secs(2)),
+            1024,
+        )
+        .await
+        .unwrap();
+        assert_eq!(Some(send), read);
+    }
+
+    #[tokio::test]
+    async fn message_io_rejects_oversized_message_test() {
+        let (mut a, mut b) = duplex(2048);
+        a.write_all(&(128u32).to_be_bytes()).await.unwrap();
+        a.write_all(&[1u8; 128]).await.unwrap();
+
+        let mut buffer = Vec::new();
+        let err = read_message_opt::<FixedMessage, _>(
+            &mut buffer,
+            &mut b,
+            Duration::from_secs(1),
+            Some(Duration::from_secs(2)),
+            64,
+        )
+        .await
+        .unwrap_err();
+
+        assert!(matches!(err, ReadMessageError::MessageTooLarge(128)));
     }
 }

--- a/src/net/messages.rs
+++ b/src/net/messages.rs
@@ -9,6 +9,9 @@ use crate::{
 
 use super::{io::SyncIO, message_io::unknown_id_err};
 
+const MAX_PEER_LIST_ITEMS: usize = 16_384;
+const MAX_LEADER_PATH_ITEMS: usize = 256;
+
 pub enum SyncRequest<I: SyncIO, D: DeterministicState> {
     MyAddress(I::Address),
     Ping(u64),
@@ -91,7 +94,7 @@ where
             3 => Self::SubscribeFresh,
             4 => Self::ShareLeaderPath,
             5 => Self::SendMePeers,
-            6 => Self::NoticePeers(read_vec(read)?),
+            6 => Self::NoticePeers(read_vec_bounded(read, MAX_PEER_LIST_ITEMS, "NoticePeers")?),
             7 => Self::SubscribeRecovery(MessageEncoding::read_from(read)?),
             8 => Self::Action {
                 source: MessageEncoding::read_from(read)?,
@@ -150,8 +153,8 @@ where
                 MessageEncoding::read_from(read)?,
                 MessageEncoding::read_from(read)?,
             ),
-            5 => Self::LeaderPath(read_vec(read)?),
-            6 => Self::Peers(read_vec(read)?),
+            5 => Self::LeaderPath(read_vec_bounded(read, MAX_LEADER_PATH_ITEMS, "LeaderPath")?),
+            6 => Self::Peers(read_vec_bounded(read, MAX_PEER_LIST_ITEMS, "Peers")?),
             other => return Err(unknown_id_err(other, "SyncResponse")),
         })
     }
@@ -168,11 +171,62 @@ fn write_vec<T: MessageEncoding, W: std::io::Write>(
     Ok(sum)
 }
 
-fn read_vec<T: MessageEncoding, R: std::io::Read>(read: &mut R) -> std::io::Result<Vec<T>> {
+fn read_vec_bounded<T: MessageEncoding, R: std::io::Read>(
+    read: &mut R,
+    max_items: usize,
+    field_name: &str,
+) -> std::io::Result<Vec<T>> {
     let count = u64::read_from(read)? as usize;
+    if max_items < count {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!("{field_name} count {count} exceeds maximum {max_items}"),
+        ));
+    }
     let mut vec = Vec::with_capacity(count);
     for _ in 0..count {
         vec.push(MessageEncoding::read_from(read)?);
     }
     Ok(vec)
+}
+
+#[cfg(test)]
+mod test {
+    use message_encoding::MessageEncoding;
+
+    use crate::testing::state_tests::TestState;
+
+    use super::*;
+
+    #[test]
+    fn sync_response_rejects_oversized_peers_test() {
+        let mut data = Vec::new();
+        6u16.write_to(&mut data).unwrap();
+        ((MAX_PEER_LIST_ITEMS + 1) as u64).write_to(&mut data).unwrap();
+
+        let err = match SyncResponse::<crate::testing::test_sync_io::TestSyncIO, TestState>::read_from(
+            &mut &data[..],
+        ) {
+            Ok(_) => panic!("expected oversized peers to fail decoding"),
+            Err(err) => err,
+        };
+        assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
+    }
+
+    #[test]
+    fn sync_response_rejects_oversized_leader_path_test() {
+        let mut data = Vec::new();
+        5u16.write_to(&mut data).unwrap();
+        ((MAX_LEADER_PATH_ITEMS + 1) as u64)
+            .write_to(&mut data)
+            .unwrap();
+
+        let err = match SyncResponse::<crate::testing::test_sync_io::TestSyncIO, TestState>::read_from(
+            &mut &data[..],
+        ) {
+            Ok(_) => panic!("expected oversized leader path to fail decoding"),
+            Err(err) => err,
+        };
+        assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
+    }
 }

--- a/src/net/messages.rs
+++ b/src/net/messages.rs
@@ -11,6 +11,7 @@ use super::{io::SyncIO, message_io::unknown_id_err};
 
 const MAX_PEER_LIST_ITEMS: usize = 16_384;
 const MAX_LEADER_PATH_ITEMS: usize = 256;
+pub const SYNC_RESPONSE_FRESH_STATE_ID: u16 = 3;
 
 pub enum SyncRequest<I: SyncIO, D: DeterministicState> {
     MyAddress(I::Address),
@@ -123,7 +124,7 @@ where
                 next_seq.write_to(out)?
             }
             Self::FreshState(state) => {
-                sum += 3u16.write_to(out)?;
+                sum += SYNC_RESPONSE_FRESH_STATE_ID.write_to(out)?;
                 state.write_to(out)?
             }
             Self::AuthorityAction(seq, action) => {
@@ -148,7 +149,7 @@ where
         Ok(match u16::read_from(read)? {
             1 => Self::Pong(MessageEncoding::read_from(read)?),
             2 => Self::RecoveryAccepted(MessageEncoding::read_from(read)?),
-            3 => Self::FreshState(MessageEncoding::read_from(read)?),
+            SYNC_RESPONSE_FRESH_STATE_ID => Self::FreshState(MessageEncoding::read_from(read)?),
             4 => Self::AuthorityAction(
                 MessageEncoding::read_from(read)?,
                 MessageEncoding::read_from(read)?,
@@ -202,14 +203,17 @@ mod test {
     fn sync_response_rejects_oversized_peers_test() {
         let mut data = Vec::new();
         6u16.write_to(&mut data).unwrap();
-        ((MAX_PEER_LIST_ITEMS + 1) as u64).write_to(&mut data).unwrap();
+        ((MAX_PEER_LIST_ITEMS + 1) as u64)
+            .write_to(&mut data)
+            .unwrap();
 
-        let err = match SyncResponse::<crate::testing::test_sync_io::TestSyncIO, TestState>::read_from(
-            &mut &data[..],
-        ) {
-            Ok(_) => panic!("expected oversized peers to fail decoding"),
-            Err(err) => err,
-        };
+        let err =
+            match SyncResponse::<crate::testing::test_sync_io::TestSyncIO, TestState>::read_from(
+                &mut &data[..],
+            ) {
+                Ok(_) => panic!("expected oversized peers to fail decoding"),
+                Err(err) => err,
+            };
         assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
     }
 
@@ -221,12 +225,13 @@ mod test {
             .write_to(&mut data)
             .unwrap();
 
-        let err = match SyncResponse::<crate::testing::test_sync_io::TestSyncIO, TestState>::read_from(
-            &mut &data[..],
-        ) {
-            Ok(_) => panic!("expected oversized leader path to fail decoding"),
-            Err(err) => err,
-        };
+        let err =
+            match SyncResponse::<crate::testing::test_sync_io::TestSyncIO, TestState>::read_from(
+                &mut &data[..],
+            ) {
+                Ok(_) => panic!("expected oversized leader path to fail decoding"),
+                Err(err) => err,
+            };
         assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
     }
 }

--- a/src/recoverable_state.rs
+++ b/src/recoverable_state.rs
@@ -175,7 +175,8 @@ impl<I: SourceId, D: DeterministicState> RecoverableState<I, D> {
 }
 
 impl MessageEncoding for RecovGenerationEnd {
-    const STATIC_SIZE: Option<usize> = m_opt_sum(&[u64::STATIC_SIZE, u64::STATIC_SIZE]);
+    const STATIC_SIZE: Option<usize> =
+        m_opt_sum(&[u64::STATIC_SIZE, u64::STATIC_SIZE, u64::STATIC_SIZE]);
 
     fn write_to<T: std::io::prelude::Write>(&self, out: &mut T) -> std::io::Result<usize> {
         let mut sum = 0;
@@ -359,5 +360,19 @@ mod test {
             state: MockState(300),
             _phantom: PhantomData::<u64>,
         });
+    }
+
+    #[test]
+    fn recov_generation_end_static_size_matches_encoding_test() {
+        let mut out = Vec::new();
+        let value = RecovGenerationEnd {
+            old_id: 10,
+            generation: 11,
+            next_sequence: 12,
+        };
+
+        let written = value.write_to(&mut out).unwrap();
+        assert_eq!(Some(written), RecovGenerationEnd::STATIC_SIZE);
+        assert_eq!(written, out.len());
     }
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -277,7 +277,7 @@ impl<D: DeterministicState> FollowUpdater<D> {
     }
 
     pub fn read_state(&self) -> RwLockReadGuard<'_, D> {
-        self.updater.inner.states[0].read()
+        self.updater.inner.read()
     }
 
     pub fn accept_seq(&self) -> u64 {
@@ -530,5 +530,17 @@ mod test {
             let read = state.read();
             assert_eq!(read.numbers.len(), 1);
         }
+    }
+
+    #[test]
+    fn follow_updater_read_state_tracks_active_buffer_test() {
+        let (_, updater) = SharedState::new(TestState::default());
+        let mut lead = updater.into_lead();
+
+        lead.queue(1);
+        assert!(lead.update());
+
+        let follow = lead.into_follow();
+        assert_eq!(follow.read_state().accept_seq, 1);
     }
 }

--- a/src/testing/fuzzy_test.rs
+++ b/src/testing/fuzzy_test.rs
@@ -7,7 +7,6 @@ use std::{
 };
 
 use rand_chacha::rand_core::{RngCore, SeedableRng};
-use tokio::sync::mpsc::channel;
 use tokio_util::sync::CancellationToken;
 
 use crate::{

--- a/src/testing/test_sync_io.rs
+++ b/src/testing/test_sync_io.rs
@@ -114,7 +114,7 @@ struct NetInner {
 struct ConnManage {
     id: u64,
     kill: Option<oneshot::Sender<TestIOKillMode>>,
-    rate_limit_bps: Arc<AtomicU64>,
+    _rate_limit_bps: Arc<AtomicU64>,
 }
 
 impl NetInner {
@@ -184,7 +184,7 @@ impl SyncIO for TestSyncIO {
             ConnManage {
                 id: conn_id,
                 kill: Some(read_kill),
-                rate_limit_bps: Arc::new(AtomicU64::new(0)),
+                _rate_limit_bps: Arc::new(AtomicU64::new(0)),
             },
         );
         lock.add_conn(
@@ -193,7 +193,7 @@ impl SyncIO for TestSyncIO {
             ConnManage {
                 id: conn_id,
                 kill: Some(write_kill),
-                rate_limit_bps: Arc::new(AtomicU64::new(0)),
+                _rate_limit_bps: Arc::new(AtomicU64::new(0)),
             },
         );
 
@@ -234,7 +234,7 @@ impl SyncIO for TestSyncIO {
             ConnManage {
                 id: conn_id,
                 kill: Some(read_kill),
-                rate_limit_bps: Arc::new(AtomicU64::new(0)),
+                _rate_limit_bps: Arc::new(AtomicU64::new(0)),
             },
         );
         lock.add_conn(
@@ -243,7 +243,7 @@ impl SyncIO for TestSyncIO {
             ConnManage {
                 id: conn_id,
                 kill: Some(write_kill),
-                rate_limit_bps: Arc::new(AtomicU64::new(0)),
+                _rate_limit_bps: Arc::new(AtomicU64::new(0)),
             },
         );
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,36 +1,14 @@
 use std::{
     fmt::Debug,
-    future::Future,
     panic::Location,
-    time::{Duration, UNIX_EPOCH},
+    time::UNIX_EPOCH,
 };
 
 pub trait LogHelper {
-    fn log(self) -> Self;
-
     fn err_log(self, msg: &str) -> Self;
 }
 
 impl<R, E: Debug> LogHelper for Result<R, E> {
-    #[track_caller]
-    fn log(self) -> Self {
-        let msg = std::any::type_name::<E>().rsplit("::").next().unwrap();
-        match self {
-            Err(error) => {
-                let caller = Location::caller();
-                tracing::error!(
-                    ?error,
-                    "Error({}:{}), {} ",
-                    caller.file(),
-                    caller.line(),
-                    msg
-                );
-                Err(error)
-            }
-            ok => ok,
-        }
-    }
-
     #[track_caller]
     fn err_log(self, msg: &str) -> Self {
         match self {
@@ -51,12 +29,6 @@ impl<R, E: Debug> LogHelper for Result<R, E> {
 }
 
 impl<R> LogHelper for Option<R> {
-    #[track_caller]
-    fn log(self) -> Self {
-        let name = std::any::type_name::<R>().rsplit("::").next().unwrap();
-        self.err_log(name)
-    }
-
     #[track_caller]
     fn err_log(self, msg: &str) -> Self {
         match self {
@@ -120,95 +92,6 @@ impl<R> PanicHelper for Option<R> {
                 tracing::error!("Panic({}:{}), {} ", caller.file(), caller.line(), msg);
                 panic!("Panic({}:{}), {} ", caller.file(), caller.line(), msg);
             }
-        }
-    }
-}
-
-pub trait TimeoutPanicHelper: Sized {
-    type Success;
-
-    #[track_caller]
-    fn timeout(self, time: Duration, msg: &str) -> impl Future<Output = Self::Success> {
-        let caller = Location::caller();
-
-        async move {
-            match self._timeout(caller, time, msg).await {
-                Ok(v) => v,
-                Err(msg) => {
-                    tracing::error!("{}", msg);
-                    panic!("{}", msg);
-                }
-            }
-        }
-    }
-
-    fn _timeout(
-        self,
-        caller: &'static Location<'static>,
-        time: Duration,
-        msg: &str,
-    ) -> impl Future<Output = Result<Self::Success, String>>;
-
-    #[cfg(test)]
-    #[track_caller]
-    fn test_timeout(self) -> impl Future<Output = Self::Success> {
-        let caller = Location::caller();
-
-        async move {
-            match self
-                ._timeout(caller, Duration::from_millis(100), "test")
-                .await
-            {
-                Ok(v) => v,
-                Err(msg) => {
-                    tracing::error!("{}", msg);
-                    panic!("{}", msg);
-                }
-            }
-        }
-    }
-
-    #[cfg(test)]
-    #[track_caller]
-    fn expect_timeout(self) -> impl Future<Output = ()> {
-        let caller = Location::caller();
-
-        async move {
-            if self
-                ._timeout(caller, Duration::from_millis(100), "")
-                .await
-                .is_ok()
-            {
-                let msg = format!(
-                    "did not get expected timeout at 100ms, {}:{}",
-                    caller.file(),
-                    caller.line()
-                );
-                tracing::error!("{}", msg);
-                panic!("{}", msg);
-            }
-        }
-    }
-}
-
-impl<F: Future> TimeoutPanicHelper for F {
-    type Success = F::Output;
-
-    async fn _timeout(
-        self,
-        caller: &'static Location<'static>,
-        time: Duration,
-        msg: &str,
-    ) -> Result<Self::Success, String> {
-        match tokio::time::timeout(time, self).await {
-            Ok(r) => Ok(r),
-            Err(_) => Err(format!(
-                "Timeout({:?}) Panic({}:{}), {} ",
-                time,
-                caller.file(),
-                caller.line(),
-                msg
-            )),
         }
     }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,8 +1,4 @@
-use std::{
-    fmt::Debug,
-    panic::Location,
-    time::UNIX_EPOCH,
-};
+use std::{fmt::Debug, panic::Location, time::UNIX_EPOCH};
 
 pub trait LogHelper {
     fn err_log(self, msg: &str) -> Self;

--- a/src/worker/sync_manager.rs
+++ b/src/worker/sync_manager.rs
@@ -145,6 +145,20 @@ pub enum Timer {
     BroadcastPeers,
 }
 
+impl Timer {
+    fn from_index(idx: usize) -> Option<Self> {
+        match idx {
+            0 => Some(Self::SendVerifyLeader),
+            1 => Some(Self::RequireVerifyLeader),
+            2 => Some(Self::RejectPeer),
+            3 => Some(Self::ConnectToPeer),
+            4 => Some(Self::RequireState),
+            5 => Some(Self::BroadcastPeers),
+            _ => None,
+        }
+    }
+}
+
 #[derive(Default)]
 struct Timers {
     next_scan: usize,
@@ -170,7 +184,9 @@ impl Timers {
         let mut timers = Vec::new();
         for (pos, state) in self.timers.iter().enumerate() {
             if state.is_set() {
-                timers.push(unsafe { std::mem::transmute::<usize, Timer>(pos) });
+                timers.push(Timer::from_index(pos).unwrap_or_else(|| {
+                    panic!("invalid timer index in active set: {pos}");
+                }));
             }
         }
         timers
@@ -212,7 +228,8 @@ impl Timers {
         };
 
         self.timers[done_timer_pos].clear();
-        unsafe { std::mem::transmute::<usize, Timer>(done_timer_pos) }
+        Timer::from_index(done_timer_pos)
+            .unwrap_or_else(|| panic!("invalid timer index while waiting: {done_timer_pos}"))
     }
 }
 
@@ -710,7 +727,7 @@ where
                 let conn_timeout = self.connect_timeout;
                 let net_settings = self.net_settings.clone();
 
-                self.last_connect_attempt = Some(connect_target.clone());
+                self.last_connect_attempt = Some(connect_target);
                 self.waiting_for_connection_update = true;
 
                 tokio::spawn(
@@ -983,7 +1000,6 @@ where
                         let now = now_ms();
                         let latency = Latency {
                             latency_ms: now.max(pong) - pong,
-                            last_pong_epoch: now,
                         };
 
                         match self.peers.entry(follow.remote) {
@@ -1677,7 +1693,6 @@ impl<I: SyncIO, D: DeterministicState> DiscoveredPeer<I, D> {
 }
 
 struct Latency {
-    last_pong_epoch: u64,
     latency_ms: u64,
 }
 
@@ -1690,6 +1705,17 @@ mod test {
     };
 
     use super::*;
+
+    #[test]
+    fn timer_from_index_test() {
+        assert_eq!(Timer::from_index(0), Some(Timer::SendVerifyLeader));
+        assert_eq!(Timer::from_index(1), Some(Timer::RequireVerifyLeader));
+        assert_eq!(Timer::from_index(2), Some(Timer::RejectPeer));
+        assert_eq!(Timer::from_index(3), Some(Timer::ConnectToPeer));
+        assert_eq!(Timer::from_index(4), Some(Timer::RequireState));
+        assert_eq!(Timer::from_index(5), Some(Timer::BroadcastPeers));
+        assert_eq!(Timer::from_index(6), None);
+    }
 
     #[tokio::test]
     async fn sync_manager_doesnt_allow_peer_with_different_leader_test() {

--- a/src/worker/sync_manager.rs
+++ b/src/worker/sync_manager.rs
@@ -21,7 +21,7 @@ use crate::{
     net::{
         io::{SyncConnection, SyncIO},
         message_channels::{NetIoSettings, ReadChannel, WriteChannel},
-        messages::{SyncRequest, SyncResponse},
+        messages::{SyncRequest, SyncResponse, SYNC_RESPONSE_FRESH_STATE_ID},
     },
     recoverable_state::{RecoverableState, RecoverableStateAction, SourceId},
     state::{DeterministicState, SharedState},
@@ -764,6 +764,10 @@ where
                                             input: conn.read,
                                             output: from_server_tx,
                                             settings: net_settings.clone(),
+                                            oversized_message_id: Some((
+                                                SYNC_RESPONSE_FRESH_STATE_ID,
+                                                net_settings.max_state_message_size,
+                                            )),
                                         }
                                         .start()
                                         .instrument(
@@ -1508,6 +1512,7 @@ where
                             input: client.read,
                             output: from_client_tx,
                             settings: net_settings.clone(),
+                            oversized_message_id: None,
                         }
                         .start()
                         .instrument(tracing::info_span!("ReadClient", remote = ?client.remote)),

--- a/src/worker/sync_updater.rs
+++ b/src/worker/sync_updater.rs
@@ -1,5 +1,6 @@
 use std::{
-    hash::{Hash, Hasher, SipHasher},
+    collections::hash_map::DefaultHasher,
+    hash::{Hash, Hasher},
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
@@ -194,7 +195,7 @@ where
 
         self.mode = match offline.try_follow(action_tx, target.authority_rx) {
             Ok(follow) => Mode::Follow(follow),
-            Err(offline) => Mode::Offline(offline),
+            Err(offline) => Mode::Offline(*offline),
         };
 
         self.is_following()
@@ -414,7 +415,7 @@ where
         mut self,
         action_tx: Sender<(I, D::Action)>,
         authority_rx: SequencedReceiver<RecoverableStateAction<I, D::AuthorityAction>>,
-    ) -> Result<FollowMode<I, D>, Self> {
+    ) -> Result<FollowMode<I, D>, Box<Self>> {
         let pair = match (SequencedRxAndUpdater {
             rx: authority_rx,
             updater: self.flushed_updater,
@@ -424,7 +425,7 @@ where
             Ok(v) => v,
             Err(pair) => {
                 self.flushed_updater = pair.updater;
-                return Err(self);
+                return Err(Box::new(self));
             }
         };
 
@@ -625,7 +626,7 @@ impl<I: SourceId, D: DeterministicState> ActionToLocalLead<I, D> {
 }
 
 fn rnd_id<S: SourceId>(local_id: S) -> u64 {
-    let mut hash = SipHasher::new();
+    let mut hash = DefaultHasher::new();
     SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .unwrap()
@@ -644,10 +645,23 @@ mod test {
             state_tests::{TestState, TestStateAction},
         },
         utils::PanicHelper,
-        worker::sync_updater::FollowTarget,
     };
-    use std::time::Duration;
+    use std::time::{Duration, Instant};
     use tokio::sync::mpsc::channel;
+
+    async fn wait_for<F: Fn() -> bool>(msg: &str, condition: F) {
+        let start = Instant::now();
+        loop {
+            if condition() {
+                return;
+            }
+            assert!(
+                start.elapsed() < Duration::from_secs(1),
+                "{msg}"
+            );
+            tokio::time::sleep(Duration::from_millis(5)).await;
+        }
+    }
 
     #[tokio::test]
     async fn sync_updater_simple_leader_test() {
@@ -658,7 +672,10 @@ mod test {
             .send(TestStateAction::Set { slot: 0, value: 33 })
             .await
             .unwrap();
-        tokio::time::sleep(Duration::from_secs(1)).await;
+        wait_for("leader did not apply local action", || {
+            a.state.read().state().numbers[0] == 33
+        })
+        .await;
         assert_eq!(a.state.read().state().numbers[0], 33);
     }
 
@@ -707,12 +724,13 @@ mod test {
             .send(TestStateAction::Set { slot: 3, value: 11 })
             .await
             .unwrap();
-        tokio::time::sleep(Duration::from_millis(10)).await;
-
-        assert_eq!(a.state().read().accept_seq(), 4);
-        assert_eq!(b.state().read().accept_seq(), 4);
-        assert_eq!(c.state().read().accept_seq(), 4);
-        assert_eq!(d.state().read().accept_seq(), 4);
+        wait_for("initial fork setup did not converge", || {
+            a.state().read().accept_seq() == 4
+                && b.state().read().accept_seq() == 4
+                && c.state().read().accept_seq() == 4
+                && d.state().read().accept_seq() == 4
+        })
+        .await;
 
         /* FORK: C lead followed by D */
         c.lead().await;
@@ -773,12 +791,13 @@ mod test {
             .await
             .unwrap();
 
-        tokio::time::sleep(Duration::from_millis(10)).await;
-
-        assert_eq!(a.state().read().accept_seq(), 8);
-        assert_eq!(b.state().read().accept_seq(), 8);
-        assert_eq!(c.state().read().accept_seq(), 8);
-        assert_eq!(d.state().read().accept_seq(), 8);
+        wait_for("forked recovery state did not converge", || {
+            a.state().read().accept_seq() == 8
+                && b.state().read().accept_seq() == 8
+                && c.state().read().accept_seq() == 8
+                && d.state().read().accept_seq() == 8
+        })
+        .await;
 
         /* a cannot recover to fork'd state */
         {
@@ -840,12 +859,13 @@ mod test {
             .send(TestStateAction::Set { slot: 3, value: 11 })
             .await
             .unwrap();
-        tokio::time::sleep(Duration::from_millis(10)).await;
-
-        assert_eq!(a.state().read().accept_seq(), 4);
-        assert_eq!(b.state().read().accept_seq(), 4);
-        assert_eq!(c.state().read().accept_seq(), 4);
-        assert_eq!(d.state().read().accept_seq(), 4);
+        wait_for("fork reject setup did not converge", || {
+            a.state().read().accept_seq() == 4
+                && b.state().read().accept_seq() == 4
+                && c.state().read().accept_seq() == 4
+                && d.state().read().accept_seq() == 4
+        })
+        .await;
 
         /* FORK: c lead and d follow c */
         c.lead().await;
@@ -894,12 +914,13 @@ mod test {
             .await
             .unwrap();
 
-        tokio::time::sleep(Duration::from_millis(10)).await;
-
-        assert_eq!(a.state().read().accept_seq(), 7);
-        assert_eq!(b.state().read().accept_seq(), 7);
-        assert_eq!(c.state().read().accept_seq(), 8);
-        assert_eq!(d.state().read().accept_seq(), 8);
+        wait_for("fork reject sequences did not converge", || {
+            a.state().read().accept_seq() == 7
+                && b.state().read().accept_seq() == 7
+                && c.state().read().accept_seq() == 8
+                && d.state().read().accept_seq() == 8
+        })
+        .await;
 
         /* a cannot recover to fork'd state */
         {
@@ -959,12 +980,13 @@ mod test {
             .send(TestStateAction::Set { slot: 3, value: 11 })
             .await
             .unwrap();
-        tokio::time::sleep(Duration::from_millis(10)).await;
-
-        assert_eq!(a.state().read().accept_seq(), 4);
-        assert_eq!(b.state().read().accept_seq(), 4);
-        assert_eq!(c.state().read().accept_seq(), 4);
-        assert_eq!(d.state().read().accept_seq(), 4);
+        wait_for("initial recovery setup did not converge", || {
+            a.state().read().accept_seq() == 4
+                && b.state().read().accept_seq() == 4
+                && c.state().read().accept_seq() == 4
+                && d.state().read().accept_seq() == 4
+        })
+        .await;
 
         /* d goes offline so we can recover later */
         d.go_offline().await;
@@ -1003,7 +1025,12 @@ mod test {
             })
             .await
             .unwrap();
-        tokio::time::sleep(Duration::from_millis(10)).await;
+        wait_for("post-B leader updates did not converge", || {
+            a.state().read().accept_seq() == 8
+                && b.state().read().accept_seq() == 8
+                && c.state().read().accept_seq() == 8
+        })
+        .await;
 
         /* promote C and have B follow */
         c.lead().await;
@@ -1039,12 +1066,13 @@ mod test {
             })
             .await
             .unwrap();
-        tokio::time::sleep(Duration::from_millis(10)).await;
-
-        assert_eq!(a.state().read().accept_seq(), 12);
-        assert_eq!(b.state().read().accept_seq(), 12);
-        assert_eq!(c.state().read().accept_seq(), 12);
-        assert_eq!(d.state().read().accept_seq(), 4);
+        wait_for("multi-generation recovery did not converge", || {
+            a.state().read().accept_seq() == 12
+                && b.state().read().accept_seq() == 12
+                && c.state().read().accept_seq() == 12
+                && d.state().read().accept_seq() == 4
+        })
+        .await;
 
         /* have D recover from A */
         {
@@ -1058,11 +1086,13 @@ mod test {
             a.provide_action_rx(action_rx);
         }
 
-        tokio::time::sleep(Duration::from_millis(10)).await;
-        assert_eq!(a.state().read().accept_seq(), 12);
-        assert_eq!(b.state().read().accept_seq(), 12);
-        assert_eq!(c.state().read().accept_seq(), 12);
-        assert_eq!(d.state().read().accept_seq(), 12);
+        wait_for("late follower recovery did not converge", || {
+            a.state().read().accept_seq() == 12
+                && b.state().read().accept_seq() == 12
+                && c.state().read().accept_seq() == 12
+                && d.state().read().accept_seq() == 12
+        })
+        .await;
 
         let a_state = a.state.read().clone();
         let b_state = b.state.read().clone();

--- a/src/worker/sync_updater.rs
+++ b/src/worker/sync_updater.rs
@@ -655,10 +655,7 @@ mod test {
             if condition() {
                 return;
             }
-            assert!(
-                start.elapsed() < Duration::from_secs(1),
-                "{msg}"
-            );
+            assert!(start.elapsed() < Duration::from_secs(1), "{msg}");
             tokio::time::sleep(Duration::from_millis(5)).await;
         }
     }


### PR DESCRIPTION
## Summary
- Added bounded decoding for network messages and peer lists to reject oversized payloads early.
- Introduced a configurable maximum message size in net IO settings and enforced it during reads.
- Fixed a `RecovGenerationEnd` static-size mismatch and added coverage for the encoded size.
- Simplified follow-state reads to track the active buffer correctly.
- Replaced unsafe timer indexing with checked mapping and tightened several sync updater behaviors.
- Stabilized flaky sync tests by waiting on concrete convergence conditions instead of fixed sleeps.
- Removed dead utility code and cleaned up unused fields/imports in test support.

## Testing
- `cargo test` not run.
- Added unit coverage for oversized message rejection in `src/net/message_io.rs`.
- Added unit coverage for oversized `Peers` and `LeaderPath` payloads in `src/net/messages.rs`.
- Added unit coverage for `RecovGenerationEnd::STATIC_SIZE` matching its encoding in `src/recoverable_state.rs`.
- Added unit coverage for `FollowUpdater::read_state()` reading the active buffer in `src/state.rs`.
- Added unit coverage for `Timer::from_index()` in `src/worker/sync_manager.rs`.
- Updated sync updater tests to poll for convergence instead of relying on fixed sleep delays.