### PR TITLE
Switch shared state replication to hotread

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -128,9 +128,9 @@ checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "hotread"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16ba220de61446580ef8a75c4b218616e00a9ba86bd2b241f137cde7f9ad522d"
+checksum = "d68ca57b725cced07dbdfd2996069ad77756256f303266a7df1452c8dff763fa"
 dependencies = [
  "parking_lot",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -127,6 +127,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
+name = "hotread"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16ba220de61446580ef8a75c4b218616e00a9ba86bd2b241f137cde7f9ad522d"
+dependencies = [
+ "parking_lot",
+]
+
+[[package]]
 name = "io-uring"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -357,6 +366,7 @@ dependencies = [
  "arc-metrics",
  "assert_matches",
  "futures-util",
+ "hotread",
  "message-encoding",
  "parking_lot",
  "rand_chacha",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,8 +18,8 @@ slab = "0.4.9"
 rand_chacha = "0.3.1"
 parking_lot = "0.12.3"
 arc-metrics = "0.1"
+hotread = "0.1.0"
 
 [dev-dependencies]
 tracing-subscriber = "0.3"
 assert_matches = "1.5.0"
-

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ slab = "0.4.9"
 rand_chacha = "0.3.1"
 parking_lot = "0.12.3"
 arc-metrics = "0.1"
-hotread = "0.1.0"
+hotread = "0.1.1"
 
 [dev-dependencies]
 tracing-subscriber = "0.3"

--- a/src/state.rs
+++ b/src/state.rs
@@ -259,16 +259,12 @@ impl<D: DeterministicState> LeadUpdater<D> {
         (seq, authority)
     }
 
-    pub fn update_ready(&mut self) -> bool {
+    pub(crate) fn update_ready(&mut self) -> bool {
         self.inner.hot.queued_update_count() > 0
     }
 
-    pub fn update(&mut self) -> bool {
+    pub(crate) fn update(&mut self) -> bool {
         self.inner.maintain()
-    }
-
-    pub fn flush(&mut self) {
-        self.inner.maintain();
     }
 
     pub fn state(&self) -> &D {
@@ -357,16 +353,12 @@ impl<D: DeterministicState> FollowUpdater<D> {
         action
     }
 
-    pub fn update_ready(&self) -> bool {
+    pub(crate) fn update_ready(&self) -> bool {
         self.inner.hot.queued_update_count() > 0
     }
 
-    pub fn update(&mut self) -> bool {
+    pub(crate) fn update(&mut self) -> bool {
         self.inner.maintain()
-    }
-
-    pub fn flush(&mut self) {
-        self.inner.maintain();
     }
 
     pub fn state(&self) -> &D {
@@ -455,7 +447,9 @@ mod test {
             updater.queue(i);
         }
 
-        updater.flush();
+        while updater.update_ready() {
+            updater.update();
+        }
 
         {
             assert_eq!(updater.accept_seq(), 20);
@@ -485,7 +479,9 @@ mod test {
 
         updater.queue(10);
         updater.queue(20);
-        updater.flush();
+        while updater.update_ready() {
+            updater.update();
+        }
 
         let current = reader.current();
         assert_eq!(current.accept_seq, 2);
@@ -525,7 +521,9 @@ mod test {
             updater.queue(i);
             updater.update();
         }
-        updater.flush();
+        while updater.update_ready() {
+            updater.update();
+        }
 
         while latest.load(Ordering::Acquire) < updater.accept_seq() {
             std::thread::yield_now();
@@ -543,7 +541,9 @@ mod test {
         let mut updater = updater.into_follow();
 
         updater.queue(0, (1, 42));
-        updater.flush();
+        while updater.update_ready() {
+            updater.update();
+        }
 
         let read = state.read();
         assert_eq!(read.accept_seq, 1);

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,18 +1,15 @@
-use parking_lot::{RwLock, RwLockReadGuard};
 use std::{
-    collections::VecDeque,
+    fmt,
     ops::{Deref, DerefMut},
-    sync::{
-        atomic::{AtomicUsize, Ordering},
-        Arc,
-    },
+    ptr::NonNull,
+    sync::Arc,
 };
 
-use crate::utils::PanicHelper;
+use hotread::{HotRead, HotReadHandle, HotReadState};
 
 pub trait DeterministicState: Sized + Send + Sync + Clone + 'static {
     type Action: Sized + Send + Sync + 'static;
-    type AuthorityAction: Sized + Send + Sync + 'static;
+    type AuthorityAction: Sized + Clone + Send + Sync + 'static;
 
     fn accept_seq(&self) -> u64;
 
@@ -21,61 +18,195 @@ pub trait DeterministicState: Sized + Send + Sync + Clone + 'static {
     fn update(&mut self, action: &Self::AuthorityAction);
 }
 
+#[derive(Clone)]
+struct HotSharedState<D: DeterministicState> {
+    state: D,
+}
+
+#[derive(Clone)]
+enum HotSharedStateUpdate<D: DeterministicState> {
+    Authority {
+        seq: u64,
+        action: D::AuthorityAction,
+    },
+    Reset(D),
+}
+
+impl<D: DeterministicState> HotReadState for HotSharedState<D> {
+    type Action = HotSharedStateUpdate<D>;
+
+    fn apply_update(&mut self, update: &Self::Action) {
+        match update {
+            HotSharedStateUpdate::Authority { seq, action } => {
+                assert_eq!(self.state.accept_seq(), *seq);
+                self.state.update(action);
+                assert_eq!(self.state.accept_seq(), seq + 1);
+            }
+            HotSharedStateUpdate::Reset(state) => {
+                self.state = state.clone();
+            }
+        }
+    }
+}
+
+struct StateInner<D: DeterministicState> {
+    hot: HotRead<HotSharedState<D>>,
+}
+
+impl<D: DeterministicState> StateInner<D> {
+    fn maintain(&self) -> bool {
+        let result = self.hot.maintain();
+
+        result.applied_updates != 0
+            || result.pruned_updates != 0
+            || result.ready_to_publish
+            || result.blocked_by_workers
+    }
+
+    fn maintain_until_flushed(&self) {
+        const MAX_SPINS: usize = 1_048_576;
+
+        for _ in 0..MAX_SPINS {
+            if self.hot.queued_update_count() == 0 {
+                return;
+            }
+
+            let result = self.hot.maintain();
+
+            if result.blocked_by_workers {
+                std::hint::spin_loop();
+            }
+        }
+
+        panic!(
+            "failed to flush shared state: stale reader handles are blocking hotread maintenance"
+        );
+    }
+
+    fn read(&self) -> SharedStateReadGuard<'_, D> {
+        let mut handle = self.hot.create_handle();
+        let state = NonNull::from(&handle.current().state);
+
+        SharedStateReadGuard { handle, state }
+    }
+
+    fn current_state(&self) -> D {
+        self.read().clone()
+    }
+}
+
 pub struct SharedState<D: DeterministicState> {
     inner: Arc<StateInner<D>>,
 }
 
-impl<D: DeterministicState + Clone> SharedState<D> {
+impl<D: DeterministicState> SharedState<D> {
     pub fn new(state: D) -> (Self, FlushedUpdater<D>) {
         let accept_seq = state.accept_seq();
 
         let inner = Arc::new(StateInner {
-            read_pos: AtomicUsize::new(0),
-            states: [RwLock::new(state.clone()), RwLock::new(state)],
+            hot: HotRead::new(HotSharedState { state }),
         });
 
         let shared = SharedState {
             inner: inner.clone(),
         };
 
-        let updater = StateUpdater {
-            inner,
-            queue: VecDeque::new(),
-            queue_offset: [0, 0],
-            queue_accept_seq: accept_seq,
-        };
-
         (
             shared,
             FlushedUpdater {
-                updater,
                 state: None,
+                inner,
+                accept_seq,
             },
         )
+    }
+
+    pub fn reader(&self) -> SharedStateReader<'_, D> {
+        SharedStateReader {
+            handle: self.inner.hot.create_handle(),
+        }
+    }
+
+    pub fn read(&self) -> SharedStateReadGuard<'_, D> {
+        self.inner.read()
+    }
+}
+
+impl<D: DeterministicState> Clone for SharedState<D> {
+    fn clone(&self) -> Self {
+        SharedState {
+            inner: self.inner.clone(),
+        }
+    }
+}
+
+pub struct SharedStateReader<'a, D: DeterministicState> {
+    handle: HotReadHandle<'a, HotSharedState<D>>,
+}
+
+impl<D: DeterministicState> SharedStateReader<'_, D> {
+    pub fn current(&mut self) -> &D {
+        &self.handle.current().state
+    }
+
+    pub fn quiescent(&mut self) {
+        self.handle.quiescent();
+    }
+}
+
+pub struct SharedStateReadGuard<'a, D: DeterministicState> {
+    handle: HotReadHandle<'a, HotSharedState<D>>,
+    state: NonNull<D>,
+}
+
+impl<D: DeterministicState> Deref for SharedStateReadGuard<'_, D> {
+    type Target = D;
+
+    fn deref(&self) -> &Self::Target {
+        let _keep_handle_alive = &self.handle;
+
+        // SAFETY: `state` points at the hotread copy selected by `handle.current()`.
+        // The handle remains live for the lifetime of this guard, so hotread will not
+        // mutate or recycle that copy until the guard is dropped.
+        unsafe { self.state.as_ref() }
+    }
+}
+
+impl<D> fmt::Debug for SharedStateReadGuard<'_, D>
+where
+    D: DeterministicState + fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Debug::fmt(&**self, f)
     }
 }
 
 pub struct FlushedUpdater<D: DeterministicState> {
     state: Option<D>,
-    updater: StateUpdater<D>,
+    inner: Arc<StateInner<D>>,
+    accept_seq: u64,
 }
 
 impl<D: DeterministicState> FlushedUpdater<D> {
     pub fn accept_seq(&self) -> u64 {
-        self.updater.queue_accept_seq
+        self.accept_seq
     }
 
     pub fn reset_state(&mut self, state: D) {
+        self.accept_seq = state.accept_seq();
         self.state = None;
-        self.updater.reset(state);
+        self.inner
+            .hot
+            .queue_update(HotSharedStateUpdate::Reset(state));
+        self.inner.maintain_until_flushed();
     }
 
     pub fn view_state<R, F: FnOnce(&D) -> R>(&self, update: F) -> R {
         if let Some(state) = &self.state {
             update(state)
         } else {
-            let state = self.updater.read();
-            update(&*state)
+            let state = self.inner.read();
+            update(&state)
         }
     }
 
@@ -89,12 +220,16 @@ impl<D: DeterministicState> FlushedUpdater<D> {
             let result = update(&mut ptr);
 
             if ptr.as_mut {
-                self.updater.reset(state.clone());
+                self.accept_seq = state.accept_seq();
+                self.inner
+                    .hot
+                    .queue_update(HotSharedStateUpdate::Reset(state.clone()));
+                self.inner.maintain_until_flushed();
             }
 
             result
         } else {
-            let mut state = self.updater.read().clone();
+            let mut state = self.inner.current_state();
 
             let mut ptr = StatePtr {
                 item: &mut state,
@@ -104,7 +239,7 @@ impl<D: DeterministicState> FlushedUpdater<D> {
             let result = update(&mut ptr);
 
             if ptr.as_mut {
-                self.updater.reset(state);
+                self.reset_state(state);
             }
 
             result
@@ -113,79 +248,61 @@ impl<D: DeterministicState> FlushedUpdater<D> {
 
     pub fn into_lead(mut self) -> LeadUpdater<D> {
         let state = match self.state.take() {
-            None => self.updater.read().clone(),
+            None => self.inner.current_state(),
             Some(state) => state,
         };
 
         LeadUpdater {
-            updater: self.updater,
+            inner: self.inner,
+            accept_seq: self.accept_seq,
             state,
         }
     }
 
     pub fn into_follow(self) -> FollowUpdater<D> {
         FollowUpdater {
-            updater: self.updater,
+            inner: self.inner,
+            accept_seq: self.accept_seq,
         }
-    }
-}
-
-impl<D: DeterministicState> Clone for SharedState<D> {
-    fn clone(&self) -> Self {
-        SharedState {
-            inner: self.inner.clone(),
-        }
-    }
-}
-
-impl<D: DeterministicState> SharedState<D> {
-    pub fn read(&self) -> RwLockReadGuard<'_, D> {
-        self.inner.read()
-    }
-}
-
-impl<D: DeterministicState> StateInner<D> {
-    pub fn read(&self) -> RwLockReadGuard<'_, D> {
-        for _ in 0..1048576 {
-            let pos = self.read_pos.load(Ordering::Acquire);
-            let idx = pos & 0x1;
-            if let Some(lock) = self.states[idx].try_read() {
-                return lock;
-            }
-            std::hint::spin_loop();
-        }
-
-        /* should not happen as read */
-        panic!("failed to acquire read lock");
     }
 }
 
 pub struct LeadUpdater<D: DeterministicState> {
-    updater: StateUpdater<D>,
+    inner: Arc<StateInner<D>>,
     state: D,
+    accept_seq: u64,
 }
 
 impl<D: DeterministicState> LeadUpdater<D> {
-    pub fn queue(&mut self, action: D::Action) -> (u64, &D::AuthorityAction) {
+    pub fn queue(&mut self, action: D::Action) -> (u64, D::AuthorityAction) {
         let authority = self.state.authority(action);
-
         let seq = self.state.accept_seq();
+
+        assert_eq!(self.accept_seq, seq);
+
         self.state.update(&authority);
-        self.updater
-            .queue_sequenced(seq, authority)
-            .panic("invalid sequence")
+        self.accept_seq = self.state.accept_seq();
+
+        self.inner
+            .hot
+            .queue_update(HotSharedStateUpdate::Authority {
+                seq,
+                action: authority.clone(),
+            });
+
+        (seq, authority)
     }
 
     pub fn update_ready(&mut self) -> bool {
-        self.updater.update_ready()
+        self.inner.hot.queued_update_count() > 0
     }
 
     pub fn update(&mut self) -> bool {
-        self.updater.update()
+        self.inner.maintain()
     }
 
     pub fn flush(&mut self) {
-        self.updater.flush_queue();
+        self.inner.maintain_until_flushed();
     }
 
     pub fn state(&self) -> &D {
@@ -193,28 +310,30 @@ impl<D: DeterministicState> LeadUpdater<D> {
     }
 
     pub fn accept_seq(&self) -> u64 {
-        self.updater.queue_accept_seq
+        self.accept_seq
     }
 
     pub fn into_follow(self) -> FollowUpdater<D> {
+        self.inner.maintain_until_flushed();
+
         FollowUpdater {
-            updater: self.updater,
+            inner: self.inner,
+            accept_seq: self.accept_seq,
         }
     }
 
-    pub fn into_flushed(mut self) -> FlushedUpdater<D> {
-        self.updater.flush_queue();
+    pub fn into_flushed(self) -> FlushedUpdater<D> {
+        self.inner.maintain_until_flushed();
 
         {
-            let state0 = self.updater.inner.states[0].read();
-            let state1 = self.updater.inner.states[1].read();
-            assert_eq!(state0.accept_seq(), state1.accept_seq());
-            assert_eq!(state0.accept_seq(), self.state.accept_seq());
+            let state = self.inner.read();
+            assert_eq!(state.accept_seq(), self.state.accept_seq());
         }
 
         FlushedUpdater {
             state: Some(self.state),
-            updater: self.updater,
+            inner: self.inner,
+            accept_seq: self.accept_seq,
         }
     }
 }
@@ -253,215 +372,81 @@ impl<T> DerefMut for StatePtr<'_, T> {
 }
 
 pub struct FollowUpdater<D: DeterministicState> {
-    updater: StateUpdater<D>,
+    inner: Arc<StateInner<D>>,
+    accept_seq: u64,
 }
 
 impl<D: DeterministicState> FollowUpdater<D> {
-    pub fn queue(&mut self, seq: u64, action: D::AuthorityAction) -> &D::AuthorityAction {
-        self.updater
-            .queue_sequenced(seq, action)
-            .panic("invalid sequence")
-            .1
+    pub fn queue(&mut self, seq: u64, action: D::AuthorityAction) -> D::AuthorityAction {
+        assert_eq!(self.accept_seq, seq);
+
+        self.inner
+            .hot
+            .queue_update(HotSharedStateUpdate::Authority {
+                seq,
+                action: action.clone(),
+            });
+
+        self.accept_seq += 1;
+        action
     }
 
     pub fn update_ready(&self) -> bool {
-        self.updater.update_ready()
+        self.inner.hot.queued_update_count() > 0
     }
 
     pub fn update(&mut self) -> bool {
-        self.updater.update()
+        self.inner.maintain()
     }
 
     pub fn flush(&mut self) {
-        self.updater.flush_queue();
+        self.inner.maintain_until_flushed();
     }
 
-    pub fn read_state(&self) -> RwLockReadGuard<'_, D> {
-        self.updater.inner.states[0].read()
-    }
-
-    pub fn accept_seq(&self) -> u64 {
-        self.updater.queue_accept_seq
-    }
-
-    pub fn into_flushed(mut self) -> FlushedUpdater<D> {
-        self.updater.flush_queue();
-
-        {
-            let state0 = self.updater.inner.states[0].read();
-            let state1 = self.updater.inner.states[1].read();
-            assert_eq!(state0.accept_seq(), state1.accept_seq());
-        }
-
-        FlushedUpdater {
-            state: None,
-            updater: self.updater,
-        }
-    }
-
-    pub fn into_lead(mut self) -> LeadUpdater<D> {
-        self.updater.flush_queue();
-
-        let state = {
-            let state0 = self.updater.inner.states[0].read();
-            let state1 = self.updater.inner.states[1].read();
-            assert_eq!(state0.accept_seq(), state1.accept_seq());
-            state0.clone()
-        };
-
-        LeadUpdater {
-            state,
-            updater: self.updater,
-        }
-    }
-}
-
-pub struct StateUpdater<D: DeterministicState> {
-    inner: Arc<StateInner<D>>,
-    queue: VecDeque<(u64, D::AuthorityAction)>,
-    queue_accept_seq: u64,
-    queue_offset: [usize; 2],
-}
-
-struct StateInner<D: DeterministicState> {
-    read_pos: AtomicUsize,
-    states: [RwLock<D>; 2],
-}
-
-impl<D: DeterministicState> StateUpdater<D> {
-    pub fn shared(&self) -> SharedState<D> {
-        SharedState {
-            inner: self.inner.clone(),
-        }
-    }
-
-    pub fn reset(&mut self, state: D) {
-        /* we're the only writer so load can be relaxed */
-        let read_pos = self.inner.read_pos.load(Ordering::Relaxed);
-
-        /* write pos shouldn't be locked or locks should be dropping soon */
-        let write_pos = read_pos.overflowing_add(1).0;
-        let write_idx = write_pos & 0x1;
-
-        let state_sequence = state.accept_seq();
-
-        {
-            let mut state_lock = self.inner.states[write_idx].write();
-            *state_lock = state.clone();
-        }
-
-        self.inner.read_pos.store(write_pos, Ordering::Release);
-
-        {
-            let mut state_lock = self.inner.states[read_pos & 0x1].write();
-            *state_lock = state;
-        }
-
-        self.queue.clear();
-        self.queue_offset = [0, 0];
-        self.queue_accept_seq = state_sequence;
-    }
-
-    pub fn queue_sequenced(
-        &mut self,
-        seq: u64,
-        item: D::AuthorityAction,
-    ) -> Result<(u64, &D::AuthorityAction), D::AuthorityAction> {
-        if self.queue_accept_seq != seq {
-            return Err(item);
-        }
-        Ok((seq, self.queue(item)))
-    }
-
-    pub fn queue(&mut self, item: D::AuthorityAction) -> &D::AuthorityAction {
-        self.queue.push_back((self.queue_accept_seq, item));
-        self.queue_accept_seq += 1;
-        &self.queue.back().unwrap().1
-    }
-
-    pub fn next_queued_sequence(&self) -> u64 {
-        self.queue_accept_seq
-    }
-
-    pub fn update_ready(&self) -> bool {
-        let read_pos = self.inner.read_pos.load(Ordering::Relaxed);
-        let write_pos = read_pos.overflowing_add(1).0;
-        self.inner.states[write_pos & 0x1].try_write().is_some()
-    }
-
-    pub fn flush_queue(&mut self) {
-        self.update();
-        self.update();
-
-        if self.update() {
-            panic!("expected update to be flushed after 2 .update() calls");
-        }
-
-        assert_eq!(self.queue.len(), 0);
-    }
-
-    pub fn read(&self) -> RwLockReadGuard<'_, D> {
+    pub fn read(&self) -> SharedStateReadGuard<'_, D> {
         self.inner.read()
     }
 
-    pub fn update(&mut self) -> bool {
-        /* we're the only writer so load can be relaxed */
-        let read_pos = self.inner.read_pos.load(Ordering::Acquire);
-
-        /* write pos shouldn't be locked or locks should be dropping soon */
-        let write_pos = read_pos.overflowing_add(1).0;
-        let write_idx = write_pos & 0x1;
-
-        let mut had_update = false;
-
-        /* apply all actions available in the queue */
-        {
-            let mut state = self.inner.states[write_idx].write();
-            let mut offset = self.queue_offset[write_idx];
-
-            let mut next_seq = state.accept_seq() + 1;
-            while offset < self.queue.len() {
-                let (target_seq, action) = &self.queue[offset];
-                assert_eq!(state.accept_seq(), *target_seq);
-                offset += 1;
-
-                had_update = true;
-                state.update(action);
-
-                assert_eq!(
-                    state.accept_seq(),
-                    next_seq,
-                    "state::update(action) did not increment sequence"
-                );
-                next_seq += 1;
-            }
-
-            self.queue_offset[write_idx] = offset;
-        }
-
-        self.trim_queue();
-
-        /* set reader to be updated pos so current reader can be updated */
-        self.inner.read_pos.store(write_pos, Ordering::Release);
-
-        had_update
+    pub fn read_state(&self) -> SharedStateReadGuard<'_, D> {
+        self.read()
     }
 
-    fn trim_queue(&mut self) {
-        let trim_size = self.queue_offset[0].min(self.queue_offset[1]);
+    pub fn accept_seq(&self) -> u64 {
+        self.accept_seq
+    }
 
-        for _ in 0..trim_size {
-            let _ = self.queue.pop_front();
+    pub fn into_flushed(self) -> FlushedUpdater<D> {
+        self.inner.maintain_until_flushed();
+
+        FlushedUpdater {
+            state: None,
+            inner: self.inner,
+            accept_seq: self.accept_seq,
         }
+    }
 
-        self.queue_offset[0] -= trim_size;
-        self.queue_offset[1] -= trim_size;
+    pub fn into_lead(self) -> LeadUpdater<D> {
+        self.inner.maintain_until_flushed();
+
+        let state = self.inner.current_state();
+
+        LeadUpdater {
+            state,
+            inner: self.inner,
+            accept_seq: self.accept_seq,
+        }
     }
 }
 
 #[cfg(test)]
 mod test {
-    use std::time::{SystemTime, UNIX_EPOCH};
+    use std::{
+        sync::{
+            atomic::{AtomicBool, AtomicU64, Ordering},
+            Arc,
+        },
+        time::{SystemTime, UNIX_EPOCH},
+    };
 
     use super::*;
 
@@ -530,5 +515,78 @@ mod test {
             let read = state.read();
             assert_eq!(read.numbers.len(), 1);
         }
+    }
+
+    #[test]
+    fn reader_handle_sees_updates() {
+        let (state, updater) = SharedState::new(TestState::default());
+        let mut updater = updater.into_lead();
+        let mut reader = state.reader();
+
+        updater.queue(10);
+        updater.queue(20);
+        updater.flush();
+
+        let current = reader.current();
+        assert_eq!(current.accept_seq, 2);
+        assert_eq!(current.numbers, vec![10, 20]);
+    }
+
+    #[test]
+    fn reader_handle_can_be_used_from_thread() {
+        let (state, updater) = SharedState::new(TestState::default());
+        let mut updater = updater.into_lead();
+        let run = Arc::new(AtomicBool::new(true));
+        let latest = Arc::new(AtomicU64::new(0));
+
+        let thread = std::thread::spawn({
+            let state = state.clone();
+            let run = run.clone();
+            let latest = latest.clone();
+
+            move || {
+                let mut reader = state.reader();
+                let mut last = 0;
+
+                while run.load(Ordering::Acquire) {
+                    let seq = reader.current().accept_seq;
+                    assert!(last <= seq);
+                    last = seq;
+                    latest.store(seq, Ordering::Release);
+                    std::hint::spin_loop();
+                }
+
+                reader.quiescent();
+                last
+            }
+        });
+
+        for i in 0..100 {
+            updater.queue(i);
+            updater.update();
+        }
+        updater.flush();
+
+        while latest.load(Ordering::Acquire) < updater.accept_seq() {
+            std::thread::yield_now();
+        }
+
+        run.store(false, Ordering::Release);
+        let observed = thread.join().unwrap();
+
+        assert_eq!(observed, updater.accept_seq());
+    }
+
+    #[test]
+    fn follow_queue_applies_directly() {
+        let (state, updater) = SharedState::new(TestState::default());
+        let mut updater = updater.into_follow();
+
+        updater.queue(0, (1, 42));
+        updater.flush();
+
+        let read = state.read();
+        assert_eq!(read.accept_seq, 1);
+        assert_eq!(read.numbers, vec![42]);
     }
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,7 +1,5 @@
 use std::{
-    fmt,
     ops::{Deref, DerefMut},
-    ptr::NonNull,
     sync::Arc,
 };
 
@@ -57,41 +55,18 @@ impl<D: DeterministicState> StateInner<D> {
     fn maintain(&self) -> bool {
         let result = self.hot.maintain();
 
-        result.applied_updates != 0
-            || result.pruned_updates != 0
-            || result.ready_to_publish
-            || result.blocked_by_workers
-    }
-
-    fn maintain_until_flushed(&self) {
-        const MAX_SPINS: usize = 1_048_576;
-
-        for _ in 0..MAX_SPINS {
-            if self.hot.queued_update_count() == 0 {
-                return;
-            }
-
-            let result = self.hot.maintain();
-
-            if result.blocked_by_workers {
-                std::hint::spin_loop();
-            }
-        }
-
-        panic!(
-            "failed to flush shared state: stale reader handles are blocking hotread maintenance"
-        );
-    }
-
-    fn read(&self) -> SharedStateReadGuard<'_, D> {
-        let mut handle = self.hot.create_handle();
-        let state = NonNull::from(&handle.current().state);
-
-        SharedStateReadGuard { handle, state }
+        result.applied_updates != 0 || result.pruned_updates != 0 || result.ready_to_publish
     }
 
     fn current_state(&self) -> D {
-        self.read().clone()
+        let mut reader = self.reader();
+        reader.current().clone()
+    }
+
+    fn reader(&self) -> SharedStateReader<'_, D> {
+        SharedStateReader {
+            handle: self.hot.create_handle(),
+        }
     }
 }
 
@@ -122,13 +97,13 @@ impl<D: DeterministicState> SharedState<D> {
     }
 
     pub fn reader(&self) -> SharedStateReader<'_, D> {
-        SharedStateReader {
-            handle: self.inner.hot.create_handle(),
-        }
+        self.inner.reader()
     }
 
-    pub fn read(&self) -> SharedStateReadGuard<'_, D> {
-        self.inner.read()
+    #[cfg(test)]
+    pub fn read(&self) -> D {
+        let mut reader = self.reader();
+        reader.current().clone()
     }
 }
 
@@ -149,35 +124,20 @@ impl<D: DeterministicState> SharedStateReader<'_, D> {
         &self.handle.current().state
     }
 
+    pub fn read(&mut self) -> &D {
+        self.current()
+    }
+
     pub fn quiescent(&mut self) {
         self.handle.quiescent();
     }
-}
 
-pub struct SharedStateReadGuard<'a, D: DeterministicState> {
-    handle: HotReadHandle<'a, HotSharedState<D>>,
-    state: NonNull<D>,
-}
-
-impl<D: DeterministicState> Deref for SharedStateReadGuard<'_, D> {
-    type Target = D;
-
-    fn deref(&self) -> &Self::Target {
-        let _keep_handle_alive = &self.handle;
-
-        // SAFETY: `state` points at the hotread copy selected by `handle.current()`.
-        // The handle remains live for the lifetime of this guard, so hotread will not
-        // mutate or recycle that copy until the guard is dropped.
-        unsafe { self.state.as_ref() }
+    pub fn generation(&self) -> u64 {
+        self.handle.generation()
     }
-}
 
-impl<D> fmt::Debug for SharedStateReadGuard<'_, D>
-where
-    D: DeterministicState + fmt::Debug,
-{
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt::Debug::fmt(&**self, f)
+    pub fn copy_index(&self) -> Option<usize> {
+        self.handle.copy_index()
     }
 }
 
@@ -194,19 +154,19 @@ impl<D: DeterministicState> FlushedUpdater<D> {
 
     pub fn reset_state(&mut self, state: D) {
         self.accept_seq = state.accept_seq();
-        self.state = None;
+        self.state = Some(state.clone());
         self.inner
             .hot
             .queue_update(HotSharedStateUpdate::Reset(state));
-        self.inner.maintain_until_flushed();
+        self.inner.maintain();
     }
 
     pub fn view_state<R, F: FnOnce(&D) -> R>(&self, update: F) -> R {
         if let Some(state) = &self.state {
             update(state)
         } else {
-            let state = self.inner.read();
-            update(&state)
+            let mut reader = self.inner.reader();
+            update(reader.current())
         }
     }
 
@@ -224,7 +184,7 @@ impl<D: DeterministicState> FlushedUpdater<D> {
                 self.inner
                     .hot
                     .queue_update(HotSharedStateUpdate::Reset(state.clone()));
-                self.inner.maintain_until_flushed();
+                self.inner.maintain();
             }
 
             result
@@ -260,9 +220,15 @@ impl<D: DeterministicState> FlushedUpdater<D> {
     }
 
     pub fn into_follow(self) -> FollowUpdater<D> {
+        let state = match self.state {
+            None => self.inner.current_state(),
+            Some(state) => state,
+        };
+
         FollowUpdater {
             inner: self.inner,
-            accept_seq: self.accept_seq,
+            accept_seq: state.accept_seq(),
+            state,
         }
     }
 }
@@ -302,7 +268,7 @@ impl<D: DeterministicState> LeadUpdater<D> {
     }
 
     pub fn flush(&mut self) {
-        self.inner.maintain_until_flushed();
+        self.inner.maintain();
     }
 
     pub fn state(&self) -> &D {
@@ -314,21 +280,17 @@ impl<D: DeterministicState> LeadUpdater<D> {
     }
 
     pub fn into_follow(self) -> FollowUpdater<D> {
-        self.inner.maintain_until_flushed();
+        self.inner.maintain();
 
         FollowUpdater {
             inner: self.inner,
             accept_seq: self.accept_seq,
+            state: self.state,
         }
     }
 
     pub fn into_flushed(self) -> FlushedUpdater<D> {
-        self.inner.maintain_until_flushed();
-
-        {
-            let state = self.inner.read();
-            assert_eq!(state.accept_seq(), self.state.accept_seq());
-        }
+        self.inner.maintain();
 
         FlushedUpdater {
             state: Some(self.state),
@@ -374,11 +336,15 @@ impl<T> DerefMut for StatePtr<'_, T> {
 pub struct FollowUpdater<D: DeterministicState> {
     inner: Arc<StateInner<D>>,
     accept_seq: u64,
+    state: D,
 }
 
 impl<D: DeterministicState> FollowUpdater<D> {
     pub fn queue(&mut self, seq: u64, action: D::AuthorityAction) -> D::AuthorityAction {
         assert_eq!(self.accept_seq, seq);
+        assert_eq!(self.state.accept_seq(), seq);
+
+        self.state.update(&action);
 
         self.inner
             .hot
@@ -387,7 +353,7 @@ impl<D: DeterministicState> FollowUpdater<D> {
                 action: action.clone(),
             });
 
-        self.accept_seq += 1;
+        self.accept_seq = self.state.accept_seq();
         action
     }
 
@@ -400,15 +366,11 @@ impl<D: DeterministicState> FollowUpdater<D> {
     }
 
     pub fn flush(&mut self) {
-        self.inner.maintain_until_flushed();
+        self.inner.maintain();
     }
 
-    pub fn read(&self) -> SharedStateReadGuard<'_, D> {
-        self.inner.read()
-    }
-
-    pub fn read_state(&self) -> SharedStateReadGuard<'_, D> {
-        self.read()
+    pub fn state(&self) -> &D {
+        &self.state
     }
 
     pub fn accept_seq(&self) -> u64 {
@@ -416,22 +378,20 @@ impl<D: DeterministicState> FollowUpdater<D> {
     }
 
     pub fn into_flushed(self) -> FlushedUpdater<D> {
-        self.inner.maintain_until_flushed();
+        self.inner.maintain();
 
         FlushedUpdater {
-            state: None,
+            state: Some(self.state),
             inner: self.inner,
             accept_seq: self.accept_seq,
         }
     }
 
     pub fn into_lead(self) -> LeadUpdater<D> {
-        self.inner.maintain_until_flushed();
-
-        let state = self.inner.current_state();
+        self.inner.maintain();
 
         LeadUpdater {
-            state,
+            state: self.state,
             inner: self.inner,
             accept_seq: self.accept_seq,
         }

--- a/src/state.rs
+++ b/src/state.rs
@@ -57,17 +57,6 @@ impl<D: DeterministicState> StateInner<D> {
 
         result.applied_updates != 0 || result.pruned_updates != 0 || result.ready_to_publish
     }
-
-    fn current_state(&self) -> D {
-        let mut reader = self.reader();
-        reader.current().clone()
-    }
-
-    fn reader(&self) -> SharedStateReader<'_, D> {
-        SharedStateReader {
-            handle: self.hot.create_handle(),
-        }
-    }
 }
 
 pub struct SharedState<D: DeterministicState> {
@@ -79,7 +68,9 @@ impl<D: DeterministicState> SharedState<D> {
         let accept_seq = state.accept_seq();
 
         let inner = Arc::new(StateInner {
-            hot: HotRead::new(HotSharedState { state }),
+            hot: HotRead::new(HotSharedState {
+                state: state.clone(),
+            }),
         });
 
         let shared = SharedState {
@@ -89,21 +80,17 @@ impl<D: DeterministicState> SharedState<D> {
         (
             shared,
             FlushedUpdater {
-                state: None,
+                state,
                 inner,
                 accept_seq,
             },
         )
     }
 
-    pub fn reader(&self) -> SharedStateReader<'_, D> {
-        self.inner.reader()
-    }
-
-    #[cfg(test)]
-    pub fn read(&self) -> D {
-        let mut reader = self.reader();
-        reader.current().clone()
+    pub fn reader(&self) -> SharedStateReader<D> {
+        SharedStateReader {
+            handle: self.inner.hot.create_handle(),
+        }
     }
 }
 
@@ -115,11 +102,11 @@ impl<D: DeterministicState> Clone for SharedState<D> {
     }
 }
 
-pub struct SharedStateReader<'a, D: DeterministicState> {
-    handle: HotReadHandle<'a, HotSharedState<D>>,
+pub struct SharedStateReader<D: DeterministicState> {
+    handle: HotReadHandle<HotSharedState<D>>,
 }
 
-impl<D: DeterministicState> SharedStateReader<'_, D> {
+impl<D: DeterministicState> SharedStateReader<D> {
     pub fn current(&mut self) -> &D {
         &self.handle.current().state
     }
@@ -142,7 +129,7 @@ impl<D: DeterministicState> SharedStateReader<'_, D> {
 }
 
 pub struct FlushedUpdater<D: DeterministicState> {
-    state: Option<D>,
+    state: D,
     inner: Arc<StateInner<D>>,
     accept_seq: u64,
 }
@@ -154,7 +141,7 @@ impl<D: DeterministicState> FlushedUpdater<D> {
 
     pub fn reset_state(&mut self, state: D) {
         self.accept_seq = state.accept_seq();
-        self.state = Some(state.clone());
+        self.state = state.clone();
         self.inner
             .hot
             .queue_update(HotSharedStateUpdate::Reset(state));
@@ -162,73 +149,41 @@ impl<D: DeterministicState> FlushedUpdater<D> {
     }
 
     pub fn view_state<R, F: FnOnce(&D) -> R>(&self, update: F) -> R {
-        if let Some(state) = &self.state {
-            update(state)
-        } else {
-            let mut reader = self.inner.reader();
-            update(reader.current())
-        }
+        update(&self.state)
     }
 
     pub fn mutate_state<R, F: FnOnce(&mut StatePtr<D>) -> R>(&mut self, update: F) -> R {
-        if let Some(state) = &mut self.state {
-            let mut ptr = StatePtr {
-                item: state,
-                as_mut: false,
-            };
-
-            let result = update(&mut ptr);
-
-            if ptr.as_mut {
-                self.accept_seq = state.accept_seq();
-                self.inner
-                    .hot
-                    .queue_update(HotSharedStateUpdate::Reset(state.clone()));
-                self.inner.maintain();
-            }
-
-            result
-        } else {
-            let mut state = self.inner.current_state();
-
-            let mut ptr = StatePtr {
-                item: &mut state,
-                as_mut: false,
-            };
-
-            let result = update(&mut ptr);
-
-            if ptr.as_mut {
-                self.reset_state(state);
-            }
-
-            result
-        }
-    }
-
-    pub fn into_lead(mut self) -> LeadUpdater<D> {
-        let state = match self.state.take() {
-            None => self.inner.current_state(),
-            Some(state) => state,
+        let mut ptr = StatePtr {
+            item: &mut self.state,
+            as_mut: false,
         };
 
+        let result = update(&mut ptr);
+
+        if ptr.as_mut {
+            self.accept_seq = self.state.accept_seq();
+            self.inner
+                .hot
+                .queue_update(HotSharedStateUpdate::Reset(self.state.clone()));
+            self.inner.maintain();
+        }
+
+        result
+    }
+
+    pub fn into_lead(self) -> LeadUpdater<D> {
         LeadUpdater {
             inner: self.inner,
             accept_seq: self.accept_seq,
-            state,
+            state: self.state,
         }
     }
 
     pub fn into_follow(self) -> FollowUpdater<D> {
-        let state = match self.state {
-            None => self.inner.current_state(),
-            Some(state) => state,
-        };
-
         FollowUpdater {
             inner: self.inner,
-            accept_seq: state.accept_seq(),
-            state,
+            accept_seq: self.accept_seq,
+            state: self.state,
         }
     }
 }
@@ -289,7 +244,7 @@ impl<D: DeterministicState> LeadUpdater<D> {
         self.inner.maintain();
 
         FlushedUpdater {
-            state: Some(self.state),
+            state: self.state,
             inner: self.inner,
             accept_seq: self.accept_seq,
         }
@@ -373,7 +328,7 @@ impl<D: DeterministicState> FollowUpdater<D> {
         self.inner.maintain();
 
         FlushedUpdater {
-            state: Some(self.state),
+            state: self.state,
             inner: self.inner,
             accept_seq: self.accept_seq,
         }
@@ -439,21 +394,24 @@ mod test {
     fn state_flush_tests() {
         let (state, updater) = SharedState::new(TestState::default());
         let mut updater = updater.into_lead();
+        let mut reader = state.reader();
 
-        assert_eq!(state.read().accept_seq, 0);
+        assert_eq!(reader.current().accept_seq, 0);
         assert_eq!(updater.accept_seq(), 0);
 
         for i in 0..20 {
             updater.queue(i);
         }
 
+        reader.current();
+        reader.quiescent();
         while updater.update_ready() {
             updater.update();
         }
 
         {
             assert_eq!(updater.accept_seq(), 20);
-            let read = state.read();
+            let read = reader.current();
             assert_eq!(read.numbers.len(), 20);
         }
 
@@ -466,7 +424,7 @@ mod test {
 
         {
             assert_eq!(updater.accept_seq(), 1000);
-            let read = state.read();
+            let read = reader.current();
             assert_eq!(read.numbers.len(), 1);
         }
     }
@@ -479,6 +437,8 @@ mod test {
 
         updater.queue(10);
         updater.queue(20);
+        reader.current();
+        reader.quiescent();
         while updater.update_ready() {
             updater.update();
         }
@@ -539,13 +499,16 @@ mod test {
     fn follow_queue_applies_directly() {
         let (state, updater) = SharedState::new(TestState::default());
         let mut updater = updater.into_follow();
+        let mut reader = state.reader();
 
         updater.queue(0, (1, 42));
+        reader.current();
+        reader.quiescent();
         while updater.update_ready() {
             updater.update();
         }
 
-        let read = state.read();
+        let read = reader.current();
         assert_eq!(read.accept_seq, 1);
         assert_eq!(read.numbers, vec![42]);
     }

--- a/src/testing/fuzzy_test.rs
+++ b/src/testing/fuzzy_test.rs
@@ -150,6 +150,11 @@ async fn _fuzzy_test() {
         node.set_leader(1).await;
     }
 
+    let mut readers: Vec<_> = sync_nodes
+        .iter()
+        .map(|node| node.shared().reader())
+        .collect();
+
     tokio::time::sleep(Duration::from_secs(12)).await;
 
     tokio::time::timeout(Duration::from_secs(300), async {
@@ -158,8 +163,8 @@ async fn _fuzzy_test() {
         loop {
             let mut has_change = false;
 
-            for (pos, node) in sync_nodes.iter().enumerate() {
-                let sequence = node.shared().read().state().accept_seq();
+            for (pos, reader) in readers.iter_mut().enumerate() {
+                let sequence = reader.current().state().accept_seq();
                 if sequences[pos] != sequence {
                     has_change = true;
                     tracing::info!(
@@ -186,19 +191,18 @@ async fn _fuzzy_test() {
     tokio::time::sleep(Duration::from_secs(2)).await;
 
     {
-        let mut iter = sync_nodes.iter();
-        let expected = iter.next().unwrap().shared().read().clone();
+        let mut iter = readers.iter_mut();
+        let expected = iter.next().unwrap().current().clone();
         assert_ne!(expected.state().numbers[0], 0);
 
-        for node in iter {
-            let shared = node.shared();
-            let state = shared.read();
+        for reader in iter {
+            let state = reader.current();
             assert_eq!(state.state(), expected.state());
         }
     }
 
     {
-        let state = sync_nodes[0].shared().read().state().clone();
+        let state = readers[0].current().state().clone();
         println!("Numbers: {:?}", state.numbers);
     }
 
@@ -210,13 +214,12 @@ async fn _fuzzy_test() {
     tokio::time::sleep(Duration::from_millis(10)).await;
 
     {
-        let mut iter = sync_nodes.iter();
-        let expected = iter.next().unwrap().shared().read().clone();
+        let mut iter = readers.iter_mut();
+        let expected = iter.next().unwrap().current().clone();
         assert_eq!(expected.state().numbers[0], 0);
 
-        for node in iter {
-            let shared = node.shared();
-            let state = shared.read();
+        for reader in iter {
+            let state = reader.current();
             assert_eq!(state.state(), expected.state());
         }
     }

--- a/src/testing/state_tests.rs
+++ b/src/testing/state_tests.rs
@@ -236,5 +236,6 @@ fn slow_state_deadlock_test() {
     }
 
     assert!(!failed.load(Ordering::SeqCst));
-    println!("{:?}", state.read());
+    let mut reader = state.reader();
+    println!("{:?}", reader.current());
 }

--- a/src/testing/state_tests.rs
+++ b/src/testing/state_tests.rs
@@ -190,13 +190,13 @@ fn slow_state_deadlock_test() {
             move || {
                 let mut update = Instant::now();
                 let mut last_sequence = 0;
+                let mut reader = state.reader();
 
                 while run.load(Ordering::Acquire) {
-                    let lock = state.read();
-                    let reader = &*lock;
+                    let state = reader.current();
 
-                    if reader.sequence != last_sequence {
-                        last_sequence = reader.sequence;
+                    if state.sequence != last_sequence {
+                        last_sequence = state.sequence;
                         update = Instant::now();
                         continue;
                     }

--- a/src/worker/follow_worker.rs
+++ b/src/worker/follow_worker.rs
@@ -84,12 +84,12 @@ where
             };
 
             let authority = self.updater.queue(seq, action);
-            self.tx.safe_send(seq, authority.clone()).await.unwrap();
+            self.tx.safe_send(seq, authority).await.unwrap();
 
             let mut remaining = 128;
             while let Ok((seq, action)) = self.rx.try_recv() {
                 let authority = self.updater.queue(seq, action);
-                self.tx.safe_send(seq, authority.clone()).await.unwrap();
+                self.tx.safe_send(seq, authority).await.unwrap();
 
                 if remaining == 0 {
                     break;
@@ -105,7 +105,7 @@ where
         /* apply pending messages */
         while let Ok((seq, action)) = self.rx.try_recv() {
             let authority = self.updater.queue(seq, action);
-            self.tx.safe_send(seq, authority.clone()).await.unwrap();
+            self.tx.safe_send(seq, authority).await.unwrap();
         }
 
         if self.updater.update_ready() {

--- a/src/worker/lead_worker.rs
+++ b/src/worker/lead_worker.rs
@@ -48,7 +48,7 @@ where
 
             let (seq, authority) = self.updater.queue(action);
             self.tx
-                .safe_send(seq, authority.clone())
+                .safe_send(seq, authority)
                 .await
                 .panic("failed to queue message in broadcast");
 
@@ -57,7 +57,7 @@ where
                 let (seq, authority) = self.updater.queue(action);
 
                 self.tx
-                    .safe_send(seq, authority.clone())
+                    .safe_send(seq, authority)
                     .await
                     .panic("failed to queue message in broadcast");
 
@@ -75,7 +75,7 @@ where
         /* apply pending messages */
         while let Ok(action) = self.rx.try_recv() {
             let (seq, authority) = self.updater.queue(action);
-            self.tx.safe_send(seq, authority.clone()).await.unwrap();
+            self.tx.safe_send(seq, authority).await.unwrap();
         }
 
         if self.updater.update_ready() {

--- a/src/worker/sync_manager.rs
+++ b/src/worker/sync_manager.rs
@@ -1721,6 +1721,9 @@ mod test {
             let _span = tracing::info_span!("C").entered();
             SyncManager::new(c, 3, TestState::default(), Default::default())
         };
+        let mut a_reader = a_work.shared().reader();
+        let mut b_reader = b_work.shared().reader();
+        let mut c_reader = c_work.shared().reader();
 
         b_work.set_leader(1).await;
         c_work.set_leader(2).await;
@@ -1731,9 +1734,9 @@ mod test {
             .unwrap();
 
         tokio::time::sleep(Duration::from_secs(2)).await;
-        assert_eq!(a_work.shared().read().state().numbers[0], 99);
-        assert_eq!(b_work.shared().read().state().numbers[0], 99);
-        assert_eq!(c_work.shared().read().state().numbers[0], 0);
+        assert_eq!(a_reader.current().state().numbers[0], 99);
+        assert_eq!(b_reader.current().state().numbers[0], 99);
+        assert_eq!(c_reader.current().state().numbers[0], 0);
 
         tokio::time::sleep(Duration::from_secs(10)).await;
     }
@@ -1768,6 +1771,9 @@ mod test {
             let _span = tracing::info_span!("C").entered();
             SyncManager::new(c, 3, TestState::default(), Default::default())
         };
+        let mut a_reader = a_work.shared().reader();
+        let mut b_reader = b_work.shared().reader();
+        let mut c_reader = c_work.shared().reader();
 
         b_work.set_leader(1).await;
         c_work.set_leader(1).await;
@@ -1780,9 +1786,12 @@ mod test {
             .unwrap();
 
         tokio::time::sleep(Duration::from_secs(2)).await;
-        assert_eq!(a_work.shared().read().state().numbers[0], 99);
-        assert_eq!(b_work.shared().read().state().numbers[0], 99);
-        assert_eq!(c_work.shared().read().state().numbers[0], 99);
+        assert_eq!(a_reader.current().state().numbers[0], 99);
+        assert_eq!(b_reader.current().state().numbers[0], 99);
+        assert_eq!(c_reader.current().state().numbers[0], 99);
+        a_reader.quiescent();
+        b_reader.quiescent();
+        c_reader.quiescent();
 
         tokio::time::sleep(Duration::from_secs(1)).await;
 
@@ -1799,9 +1808,9 @@ mod test {
         .unwrap();
 
         tokio::time::sleep(Duration::from_secs(3)).await;
-        assert_eq!(a_work.shared().read().state().numbers[0], 199);
-        assert_eq!(b_work.shared().read().state().numbers[0], 199);
-        assert_eq!(c_work.shared().read().state().numbers[0], 199);
+        assert_eq!(a_reader.current().state().numbers[0], 199);
+        assert_eq!(b_reader.current().state().numbers[0], 199);
+        assert_eq!(c_reader.current().state().numbers[0], 199);
 
         println!("DONE");
     }
@@ -1832,6 +1841,8 @@ mod test {
             let _span = tracing::info_span!("C").entered();
             SyncManager::new(c, 3, TestState::default(), Default::default())
         };
+        let mut a_reader = a_work.shared().reader();
+        let mut c_reader = c_work.shared().reader();
 
         c_work.set_leader(1).await;
 
@@ -1841,7 +1852,8 @@ mod test {
             .unwrap();
 
         tokio::time::sleep(Duration::from_secs(2)).await;
-        assert_eq!(c_work.shared().read().state().numbers[0], 99);
+        assert_eq!(c_reader.current().state().numbers[0], 99);
+        c_reader.quiescent();
 
         test_net.block_connection(1, 2, true).await;
 
@@ -1857,11 +1869,13 @@ mod test {
                 },
             )
         };
+        let mut b_reader = b_work.shared().reader();
 
         b_work.set_leader(1).await;
 
         tokio::time::sleep(Duration::from_secs(3)).await;
-        assert_eq!(b_work.shared().read().state().numbers[0], 99);
+        assert_eq!(b_reader.current().state().numbers[0], 99);
+        b_reader.quiescent();
 
         tx.send(TestStateAction::Add {
             slot: 0,
@@ -1871,9 +1885,9 @@ mod test {
         .unwrap();
 
         tokio::time::sleep(Duration::from_secs(3)).await;
-        assert_eq!(a_work.shared().read().state().numbers[0], 199);
-        assert_eq!(b_work.shared().read().state().numbers[0], 199);
-        assert_eq!(c_work.shared().read().state().numbers[0], 199);
+        assert_eq!(a_reader.current().state().numbers[0], 199);
+        assert_eq!(b_reader.current().state().numbers[0], 199);
+        assert_eq!(c_reader.current().state().numbers[0], 199);
     }
 
     #[tokio::test]

--- a/src/worker/sync_updater.rs
+++ b/src/worker/sync_updater.rs
@@ -209,7 +209,8 @@ where
         }
 
         let leader_recovery_details = {
-            let read = self.state.read();
+            let mut reader = self.state.reader();
+            let read = reader.current();
             let details = read.details();
             if !details.can_recover_follower(&recovery_details) {
                 return None;
@@ -237,8 +238,8 @@ where
         }
 
         let state = {
-            let read = self.state.read();
-            read.clone()
+            let mut reader = self.state.reader();
+            reader.current().clone()
         };
 
         let sub = match self.broadcast.add_client(state.accept_seq(), true).await {
@@ -273,11 +274,13 @@ where
     }
 
     pub async fn clone_state(&self) -> RecoverableState<I, D> {
-        self.state.read().clone()
+        let mut reader = self.state.reader();
+        reader.current().clone()
     }
 
     pub async fn state_recovery_details(&self) -> RecoverableStateDetails {
-        self.state.read().details().clone()
+        let mut reader = self.state.reader();
+        reader.current().details().clone()
     }
 }
 

--- a/src/worker/sync_updater.rs
+++ b/src/worker/sync_updater.rs
@@ -3,6 +3,7 @@ use std::{
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
+use parking_lot::Mutex;
 use sequenced_broadcast::{
     NewClientError, SequencedBroadcast, SequencedBroadcastSettings, SequencedReceiver,
     SequencedSender,
@@ -14,7 +15,7 @@ use crate::{
     recoverable_state::{
         RecoverableState, RecoverableStateAction, RecoverableStateDetails, SourceId,
     },
-    state::{DeterministicState, FlushedUpdater, SharedState},
+    state::{DeterministicState, FlushedUpdater, SharedState, SharedStateReader},
     utils::{LogHelper, PanicHelper},
 };
 
@@ -30,6 +31,7 @@ pub struct SyncUpdater<I: SourceId, D: DeterministicState> {
     pub(super) local_action_tx: Sender<D::Action>,
     pub(super) action_tx: Sender<(I, D::Action)>,
     pub(super) state: SharedState<RecoverableState<I, D>>,
+    state_reader: Mutex<SharedStateReader<RecoverableState<I, D>>>,
 
     mode: Mode<I, D>,
 
@@ -50,6 +52,7 @@ where
 {
     pub fn new(local_id: I, state: D, broadcast_settings: SequencedBroadcastSettings) -> Self {
         let (state, updater) = SharedState::new(RecoverableState::new(rnd_id(local_id), state));
+        let state_reader = Mutex::new(state.reader());
 
         let (local_action_tx, mut local_action_rx) = channel(2048);
         let (action_tx, action_rx) = channel(2048);
@@ -89,6 +92,7 @@ where
             action_tx,
             local_action_tx,
             state,
+            state_reader,
             mode,
             broadcast_settings,
             broadcast,
@@ -209,13 +213,17 @@ where
         }
 
         let leader_recovery_details = {
-            let mut reader = self.state.reader();
+            let mut reader = self.state_reader.lock();
             let read = reader.current();
             let details = read.details();
-            if !details.can_recover_follower(&recovery_details) {
+            let can_recover = details.can_recover_follower(&recovery_details);
+            let details = details.clone();
+            reader.quiescent();
+
+            if !can_recover {
                 return None;
             }
-            details.clone()
+            details
         };
 
         let recv = self
@@ -238,8 +246,10 @@ where
         }
 
         let state = {
-            let mut reader = self.state.reader();
-            reader.current().clone()
+            let mut reader = self.state_reader.lock();
+            let state = reader.current().clone();
+            reader.quiescent();
+            state
         };
 
         let sub = match self.broadcast.add_client(state.accept_seq(), true).await {
@@ -274,13 +284,17 @@ where
     }
 
     pub async fn clone_state(&self) -> RecoverableState<I, D> {
-        let mut reader = self.state.reader();
-        reader.current().clone()
+        let mut reader = self.state_reader.lock();
+        let state = reader.current().clone();
+        reader.quiescent();
+        state
     }
 
     pub async fn state_recovery_details(&self) -> RecoverableStateDetails {
-        let mut reader = self.state.reader();
-        reader.current().details().clone()
+        let mut reader = self.state_reader.lock();
+        let details = reader.current().details().clone();
+        reader.quiescent();
+        details
     }
 }
 
@@ -657,12 +671,13 @@ mod test {
         setup_logging();
 
         let a = SyncUpdater::<u64, TestState>::new(1, Default::default(), Default::default());
+        let mut a_reader = a.state.reader();
         a.local_action_tx
             .send(TestStateAction::Set { slot: 0, value: 33 })
             .await
             .unwrap();
         tokio::time::sleep(Duration::from_secs(1)).await;
-        assert_eq!(a.state.read().state().numbers[0], 33);
+        assert_eq!(a_reader.current().state().numbers[0], 33);
     }
 
     #[tokio::test]
@@ -671,6 +686,10 @@ mod test {
         let mut b = SyncUpdater::<u64, TestState>::new(2, Default::default(), Default::default());
         let mut c = SyncUpdater::<u64, TestState>::new(3, Default::default(), Default::default());
         let mut d = SyncUpdater::<u64, TestState>::new(4, Default::default(), Default::default());
+        let mut a_reader = a.state.reader();
+        let mut b_reader = b.state.reader();
+        let mut c_reader = c.state.reader();
+        let mut d_reader = d.state.reader();
 
         /* all follow A */
         {
@@ -712,10 +731,14 @@ mod test {
             .unwrap();
         tokio::time::sleep(Duration::from_millis(10)).await;
 
-        assert_eq!(a.state().read().accept_seq(), 4);
-        assert_eq!(b.state().read().accept_seq(), 4);
-        assert_eq!(c.state().read().accept_seq(), 4);
-        assert_eq!(d.state().read().accept_seq(), 4);
+        assert_eq!(a_reader.current().accept_seq(), 4);
+        assert_eq!(b_reader.current().accept_seq(), 4);
+        assert_eq!(c_reader.current().accept_seq(), 4);
+        assert_eq!(d_reader.current().accept_seq(), 4);
+        a_reader.quiescent();
+        b_reader.quiescent();
+        c_reader.quiescent();
+        d_reader.quiescent();
 
         /* FORK: C lead followed by D */
         c.lead().await;
@@ -778,10 +801,14 @@ mod test {
 
         tokio::time::sleep(Duration::from_millis(10)).await;
 
-        assert_eq!(a.state().read().accept_seq(), 8);
-        assert_eq!(b.state().read().accept_seq(), 8);
-        assert_eq!(c.state().read().accept_seq(), 8);
-        assert_eq!(d.state().read().accept_seq(), 8);
+        assert_eq!(a_reader.current().accept_seq(), 8);
+        assert_eq!(b_reader.current().accept_seq(), 8);
+        assert_eq!(c_reader.current().accept_seq(), 8);
+        assert_eq!(d_reader.current().accept_seq(), 8);
+        a_reader.quiescent();
+        b_reader.quiescent();
+        c_reader.quiescent();
+        d_reader.quiescent();
 
         /* a cannot recover to fork'd state */
         {
@@ -804,6 +831,10 @@ mod test {
         let mut b = SyncUpdater::<u64, TestState>::new(2, Default::default(), Default::default());
         let mut c = SyncUpdater::<u64, TestState>::new(3, Default::default(), Default::default());
         let mut d = SyncUpdater::<u64, TestState>::new(4, Default::default(), Default::default());
+        let mut a_reader = a.state.reader();
+        let mut b_reader = b.state.reader();
+        let mut c_reader = c.state.reader();
+        let mut d_reader = d.state.reader();
 
         /* all follow A */
         {
@@ -845,10 +876,14 @@ mod test {
             .unwrap();
         tokio::time::sleep(Duration::from_millis(10)).await;
 
-        assert_eq!(a.state().read().accept_seq(), 4);
-        assert_eq!(b.state().read().accept_seq(), 4);
-        assert_eq!(c.state().read().accept_seq(), 4);
-        assert_eq!(d.state().read().accept_seq(), 4);
+        assert_eq!(a_reader.current().accept_seq(), 4);
+        assert_eq!(b_reader.current().accept_seq(), 4);
+        assert_eq!(c_reader.current().accept_seq(), 4);
+        assert_eq!(d_reader.current().accept_seq(), 4);
+        a_reader.quiescent();
+        b_reader.quiescent();
+        c_reader.quiescent();
+        d_reader.quiescent();
 
         /* FORK: c lead and d follow c */
         c.lead().await;
@@ -899,10 +934,14 @@ mod test {
 
         tokio::time::sleep(Duration::from_millis(10)).await;
 
-        assert_eq!(a.state().read().accept_seq(), 7);
-        assert_eq!(b.state().read().accept_seq(), 7);
-        assert_eq!(c.state().read().accept_seq(), 8);
-        assert_eq!(d.state().read().accept_seq(), 8);
+        assert_eq!(a_reader.current().accept_seq(), 7);
+        assert_eq!(b_reader.current().accept_seq(), 7);
+        assert_eq!(c_reader.current().accept_seq(), 8);
+        assert_eq!(d_reader.current().accept_seq(), 8);
+        a_reader.quiescent();
+        b_reader.quiescent();
+        c_reader.quiescent();
+        d_reader.quiescent();
 
         /* a cannot recover to fork'd state */
         {
@@ -925,6 +964,10 @@ mod test {
         let mut b = SyncUpdater::<u64, TestState>::new(2, Default::default(), Default::default());
         let mut c = SyncUpdater::<u64, TestState>::new(3, Default::default(), Default::default());
         let mut d = SyncUpdater::<u64, TestState>::new(4, Default::default(), Default::default());
+        let mut a_reader = a.state.reader();
+        let mut b_reader = b.state.reader();
+        let mut c_reader = c.state.reader();
+        let mut d_reader = d.state.reader();
 
         {
             let follow = a.add_fresh_subscriber().await.unwrap();
@@ -964,10 +1007,14 @@ mod test {
             .unwrap();
         tokio::time::sleep(Duration::from_millis(10)).await;
 
-        assert_eq!(a.state().read().accept_seq(), 4);
-        assert_eq!(b.state().read().accept_seq(), 4);
-        assert_eq!(c.state().read().accept_seq(), 4);
-        assert_eq!(d.state().read().accept_seq(), 4);
+        assert_eq!(a_reader.current().accept_seq(), 4);
+        assert_eq!(b_reader.current().accept_seq(), 4);
+        assert_eq!(c_reader.current().accept_seq(), 4);
+        assert_eq!(d_reader.current().accept_seq(), 4);
+        a_reader.quiescent();
+        b_reader.quiescent();
+        c_reader.quiescent();
+        d_reader.quiescent();
 
         /* d goes offline so we can recover later */
         d.go_offline().await;
@@ -1044,10 +1091,14 @@ mod test {
             .unwrap();
         tokio::time::sleep(Duration::from_millis(10)).await;
 
-        assert_eq!(a.state().read().accept_seq(), 12);
-        assert_eq!(b.state().read().accept_seq(), 12);
-        assert_eq!(c.state().read().accept_seq(), 12);
-        assert_eq!(d.state().read().accept_seq(), 4);
+        assert_eq!(a_reader.current().accept_seq(), 12);
+        assert_eq!(b_reader.current().accept_seq(), 12);
+        assert_eq!(c_reader.current().accept_seq(), 12);
+        assert_eq!(d_reader.current().accept_seq(), 4);
+        a_reader.quiescent();
+        b_reader.quiescent();
+        c_reader.quiescent();
+        d_reader.quiescent();
 
         /* have D recover from A */
         {
@@ -1062,15 +1113,19 @@ mod test {
         }
 
         tokio::time::sleep(Duration::from_millis(10)).await;
-        assert_eq!(a.state().read().accept_seq(), 12);
-        assert_eq!(b.state().read().accept_seq(), 12);
-        assert_eq!(c.state().read().accept_seq(), 12);
-        assert_eq!(d.state().read().accept_seq(), 12);
+        assert_eq!(a_reader.current().accept_seq(), 12);
+        assert_eq!(b_reader.current().accept_seq(), 12);
+        assert_eq!(c_reader.current().accept_seq(), 12);
+        assert_eq!(d_reader.current().accept_seq(), 12);
 
-        let a_state = a.state.read().clone();
-        let b_state = b.state.read().clone();
-        let c_state = c.state.read().clone();
-        let d_state = d.state.read().clone();
+        let a_state = a_reader.current().clone();
+        let b_state = b_reader.current().clone();
+        let c_state = c_reader.current().clone();
+        let d_state = d_reader.current().clone();
+        a_reader.quiescent();
+        b_reader.quiescent();
+        c_reader.quiescent();
+        d_reader.quiescent();
 
         assert_eq!(a_state, b_state);
         assert_eq!(a_state, c_state);
@@ -1087,6 +1142,9 @@ mod test {
         let mut a = SyncUpdater::<u64, TestState>::new(1, Default::default(), Default::default());
         let mut b = SyncUpdater::<u64, TestState>::new(2, Default::default(), Default::default());
         let mut c = SyncUpdater::<u64, TestState>::new(3, Default::default(), Default::default());
+        let mut a_reader = a.state.reader();
+        let mut b_reader = b.state.reader();
+        let mut c_reader = c.state.reader();
 
         {
             let follow = a.add_fresh_subscriber().await.unwrap();
@@ -1119,9 +1177,12 @@ mod test {
 
         tokio::time::sleep(Duration::from_millis(200)).await;
 
-        let a_state = a.state.read().clone();
-        let b_state = b.state.read().clone();
-        let c_state = c.state.read().clone();
+        let a_state = a_reader.current().clone();
+        let b_state = b_reader.current().clone();
+        let c_state = c_reader.current().clone();
+        a_reader.quiescent();
+        b_reader.quiescent();
+        c_reader.quiescent();
 
         assert_eq!(a_state, b_state);
         assert_eq!(a_state, c_state);
@@ -1159,8 +1220,10 @@ mod test {
             .unwrap();
         tokio::time::sleep(Duration::from_millis(200)).await;
 
-        let a_state = a.state.read().clone();
-        let b_state = b.state.read().clone();
+        let a_state = a_reader.current().clone();
+        let b_state = b_reader.current().clone();
+        a_reader.quiescent();
+        b_reader.quiescent();
         assert_eq!(a_state, b_state);
         assert_eq!(a_state.state().numbers[1], 88);
         assert_eq!(a_state.state().numbers[2], 22);
@@ -1176,9 +1239,12 @@ mod test {
             .unwrap();
         tokio::time::sleep(Duration::from_millis(200)).await;
 
-        let a_state = a.state.read().clone();
-        let b_state = b.state.read().clone();
-        let c_state = c.state.read().clone();
+        let a_state = a_reader.current().clone();
+        let b_state = b_reader.current().clone();
+        let c_state = c_reader.current().clone();
+        a_reader.quiescent();
+        b_reader.quiescent();
+        c_reader.quiescent();
 
         assert_eq!(a_state, b_state);
         assert_eq!(a_state, c_state);


### PR DESCRIPTION
## Summary
- Replace the previous double-buffered `RwLock` state replication with `hotread`-backed shared state storage.
- Add read handles that can be used across threads while preserving quiescent-safe access to the current state.
- Update lead/follow updater flows to queue cloned authority actions directly and flush through hotread maintenance.
- Add tests covering reader visibility, cross-thread reads, and follow-mode updates.

## Testing
- Not run (no test command executed in this session).
- Added unit coverage for reader handle updates, threaded reader access, and follow queue behavior.
- Existing worker call sites updated to match the new `queue` return types and ownership model.