### PR TITLE
Tighten remote leader path validation

### DIFF
--- a/src/shared/node.rs
+++ b/src/shared/node.rs
@@ -603,7 +603,7 @@ impl<A: SyncIOAddress, D: DeterministicState> Inner<A, D> {
                 let has_valid_relay_path = observation
                     .leader_path
                     .as_deref()
-                    .map(|path| valid_remote_leader_path(Some(leader), path, self.address))
+                    .map(|path| valid_remote_leader_path(Some(leader), path, observation.observer, self.address))
                     .unwrap_or(false);
                 let leader_is_failed = control
                     .peers
@@ -1121,7 +1121,7 @@ where
             return;
         };
 
-        if !valid_remote_leader_path(Some(leader), &path, self.inner.address) {
+        if !valid_remote_leader_path(Some(leader), &path, target, self.inner.address) {
             self.mark_connect_fail(target).await;
             return;
         }
@@ -1201,7 +1201,7 @@ where
                     }
                     Some(SyncResponse::LeaderInfo(info)) => match (info.leader, info.path) {
                         (Some(leader_addr), Some(path))
-                            if valid_remote_leader_path(Some(leader_addr), &path, inner.address) =>
+                            if valid_remote_leader_path(Some(leader_addr), &path, target, inner.address) =>
                         {
                             inner
                                 .set_remote_leader_path(
@@ -1220,7 +1220,7 @@ where
                     },
                     Some(SyncResponse::LeaderPath(path)) => {
                         if let Some(leader_addr) = path.first().copied() {
-                            if valid_remote_leader_path(Some(leader_addr), &path, inner.address) {
+                            if valid_remote_leader_path(Some(leader_addr), &path, target, inner.address) {
                                 inner
                                     .set_remote_leader_path(
                                         leader_addr,
@@ -1284,7 +1284,9 @@ where
                         !observation
                             .leader_path
                             .as_deref()
-                            .map(|path| valid_remote_leader_path(Some(target), path, self.inner.address))
+                            .map(|path| {
+                                valid_remote_leader_path(Some(target), path, observation.observer, self.inner.address)
+                            })
                             .unwrap_or(false)
                     })
                     .unwrap_or(false);
@@ -1303,7 +1305,7 @@ where
                 observation
                     .leader_path
                     .as_deref()
-                    .map(|path| valid_remote_leader_path(Some(target), path, self.inner.address))
+                    .map(|path| valid_remote_leader_path(Some(target), path, *observer, self.inner.address))
                     .unwrap_or(false)
             });
             let has_relay_follow = control

--- a/src/shared/node/election.rs
+++ b/src/shared/node/election.rs
@@ -74,7 +74,7 @@ pub(super) fn decide_election<A: SyncIOAddress>(input: ElectionInput<A>) -> Elec
             if !valid_local_leader_path(Some(leader), path, input.local_address) {
                 continue;
             }
-        } else if !valid_remote_leader_path(Some(leader), path, input.local_address) {
+        } else if !valid_remote_leader_path(Some(leader), path, observation.observer, input.local_address) {
             continue;
         }
         let local_path = if observation.observer == input.local_address {

--- a/src/shared/node/paths.rs
+++ b/src/shared/node/paths.rs
@@ -2,7 +2,7 @@ use std::collections::HashSet;
 
 use crate::net::sync_io::SyncIOAddress;
 
-pub(super) fn valid_remote_leader_path<A: SyncIOAddress>(leader: Option<A>, path: &[A], local: A) -> bool {
+pub(super) fn valid_remote_leader_path<A: SyncIOAddress>(leader: Option<A>, path: &[A], remote: A, local: A) -> bool {
     let Some(leader) = leader else {
         return false;
     };
@@ -17,7 +17,11 @@ pub(super) fn valid_remote_leader_path<A: SyncIOAddress>(leader: Option<A>, path
         }
     }
 
-    !path.iter().skip(1).any(|step| *step == local)
+    path.last().copied() == Some(remote)
+        && !path
+            .iter()
+            .enumerate()
+            .any(|(idx, step)| *step == local && !(idx == 0 && leader == local))
 }
 
 pub(super) fn valid_local_leader_path<A: SyncIOAddress>(leader: Option<A>, path: &[A], local: A) -> bool {

--- a/src/shared/node/test.rs
+++ b/src/shared/node/test.rs
@@ -229,10 +229,12 @@ mod fuzzy;
 
 #[test]
 fn remote_leader_path_rejects_cycles_and_local_node() {
-    assert!(valid_remote_leader_path(Some(1), &[1, 2], 3));
-    assert!(!valid_remote_leader_path(Some(1), &[1, 2, 3], 3));
-    assert!(!valid_remote_leader_path(Some(1), &[1, 2, 2], 3));
-    assert!(!valid_remote_leader_path(Some(2), &[1, 2], 3));
+    assert!(valid_remote_leader_path(Some(1), &[1, 2], 2, 3));
+    assert!(valid_remote_leader_path(Some(1), &[1], 1, 3));
+    assert!(!valid_remote_leader_path(Some(1), &[1, 2], 4, 3));
+    assert!(!valid_remote_leader_path(Some(1), &[1, 2, 3], 3, 3));
+    assert!(!valid_remote_leader_path(Some(1), &[1, 2, 2], 2, 3));
+    assert!(!valid_remote_leader_path(Some(2), &[1, 2], 2, 3));
 }
 
 #[test]

--- a/src/state/determinstic_state.rs
+++ b/src/state/determinstic_state.rs
@@ -4,6 +4,14 @@ pub trait DeterministicState: Sized + Send + Sync + Clone + 'static {
 
     fn accept_seq(&self) -> u64;
 
+    /// Converts a client action into an authority action.
+    ///
+    /// This method must not rely on observing effects from recently returned
+    /// authority actions. Leaders may enqueue authority actions before the
+    /// local hot-read snapshot has applied earlier actions, and forwarded
+    /// actions may be authorized concurrently. Use this for stateless wrapping
+    /// or validation of client context; state-dependent sequencing should
+    /// happen in `update`.
     fn authority(&self, action: Self::Action) -> Self::AuthorityAction;
 
     fn update(&mut self, action: &Self::AuthorityAction);


### PR DESCRIPTION
## Summary
- Pass the observed remote peer into remote leader path validation so paths are checked against the node that actually reported them.
- Reject remote leader paths whose tail does not match the observed peer, while still allowing the local leader to appear at the head of a self-originated path.
- Update election and sync handling to use the stricter validation everywhere remote paths are consumed.
- Add coverage for valid and invalid remote leader path shapes.
- Document `DeterministicState::authority` to clarify that it must remain stateless with respect to recently applied authority actions.

## Testing
- Ran/updated unit coverage in `src/shared/node/test.rs` for remote leader path validation cases.
- Not run: full `cargo test` suite.
- Not run: integration or distributed election scenarios.