### PR TITLE
Handle EOF close frames in net I/O

### DIFF
--- a/src/net/message_channel.rs
+++ b/src/net/message_channel.rs
@@ -1,10 +1,11 @@
 use std::time::Duration;
 
 use message_encoding::MessageEncoding;
+use tokio::io::AsyncWriteExt;
 use tokio::sync::mpsc::{Receiver, Sender};
 
 use super::{
-    message_io::{read_message_opt, send_message, send_zero_message},
+    message_io::{read_message_opt, send_close_message, send_message, send_zero_message, ReadMessageResult},
     sync_io::SyncIO,
 };
 
@@ -56,14 +57,18 @@ impl<I: SyncIO, M: MessageEncoding + Send + Sync + 'static> ReadChannel<I, M> {
             };
 
             match read_opt_res {
-                Ok(Some(msg)) => {
+                Ok(ReadMessageResult::Message(msg)) => {
                     if self.output.send(msg).await.is_err() {
                         tracing::error!("failed to send message to output, stopping read");
                         break;
                     }
                 }
-                Ok(None) => {
+                Ok(ReadMessageResult::KeepAlive) => {
                     continue;
+                }
+                Ok(ReadMessageResult::Close) => {
+                    tracing::info!("remote closed connection");
+                    break;
                 }
                 Err(error) => {
                     tracing::error!(?error, "failed to read from network");
@@ -87,7 +92,19 @@ impl<I: SyncIO, M: MessageEncoding + Send + Sync + 'static> WriteChannel<I, M> {
                     match msg_opt {
                         Some(v) => Some(v),
                         None => {
-                            tracing::info!("input closed, ending write");
+                            tracing::info!("input closed, closing write");
+                            let close_res = tokio::time::timeout(
+                                self.settings.process_timeout,
+                                send_close_message(&mut self.output),
+                            )
+                            .await;
+
+                            match close_res {
+                                Ok(Ok(())) => {}
+                                Ok(Err(error)) => tracing::debug!(?error, "failed to send close message"),
+                                Err(error) => tracing::debug!(?error, "timed out sending close message"),
+                            }
+
                             break;
                         }
                     }
@@ -106,10 +123,104 @@ impl<I: SyncIO, M: MessageEncoding + Send + Sync + 'static> WriteChannel<I, M> {
                 None => tokio::time::timeout(self.settings.process_timeout, send_zero_message(&mut self.output)).await,
             };
 
-            if let Err(error) = send_res {
-                tracing::error!(?error, "failed to send message, closing write");
-                break;
+            match send_res {
+                Ok(Ok(())) => {}
+                Ok(Err(error)) => {
+                    tracing::error!(?error, "failed to send message, closing write");
+                    break;
+                }
+                Err(error) => {
+                    tracing::error!(?error, "timed out sending message, closing write");
+                    break;
+                }
             }
         }
+
+        let shutdown_res = tokio::time::timeout(self.settings.process_timeout, self.output.shutdown()).await;
+        match shutdown_res {
+            Ok(Ok(())) => {}
+            Ok(Err(error)) => tracing::debug!(?error, "failed to shutdown write"),
+            Err(error) => tracing::debug!(?error, "timed out shutting down write"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{future::Future, time::Duration};
+
+    use tokio::{
+        io::{duplex, AsyncReadExt, DuplexStream},
+        sync::mpsc,
+    };
+
+    use super::*;
+    use crate::net::{
+        message_io::{send_close_message, MessageSizeHeader},
+        sync_io::{SyncConnection, SyncIO},
+    };
+
+    struct DuplexSyncIo;
+
+    impl SyncIO for DuplexSyncIo {
+        type Address = u64;
+        type Read = DuplexStream;
+        type Write = DuplexStream;
+
+        fn connect(
+            &self,
+            _remote: &Self::Address,
+        ) -> impl Future<Output = std::io::Result<SyncConnection<Self>>> + Send {
+            async { Err(std::io::Error::new(std::io::ErrorKind::Unsupported, "test io cannot connect")) }
+        }
+    }
+
+    fn test_settings() -> NetIoSettings {
+        NetIoSettings {
+            process_timeout: Duration::from_secs(1),
+            message_timeout: Duration::from_secs(1),
+        }
+    }
+
+    #[tokio::test]
+    async fn write_channel_sends_close_when_input_closes() {
+        let (output, mut peer_read) = duplex(64);
+        let (tx, rx) = mpsc::channel::<u64>(1);
+        drop(tx);
+
+        let handle = tokio::spawn(
+            WriteChannel::<DuplexSyncIo, u64> {
+                input: rx,
+                output,
+                settings: test_settings(),
+            }
+            .start(),
+        );
+
+        let mut header = [0; std::mem::size_of::<MessageSizeHeader>()];
+        peer_read.read_exact(&mut header).await.unwrap();
+        handle.await.unwrap();
+
+        assert_eq!(header, MessageSizeHeader::MAX.to_be_bytes());
+    }
+
+    #[tokio::test]
+    async fn read_channel_stops_without_message_on_close_frame() {
+        let (input, mut peer_write) = duplex(64);
+        let (tx, mut rx) = mpsc::channel::<u64>(1);
+
+        let handle = tokio::spawn(
+            ReadChannel::<DuplexSyncIo, u64> {
+                input,
+                output: tx,
+                settings: test_settings(),
+            }
+            .start(),
+        );
+
+        send_close_message(&mut peer_write).await.unwrap();
+        handle.await.unwrap();
+
+        assert!(rx.recv().await.is_none());
     }
 }

--- a/src/net/message_io.rs
+++ b/src/net/message_io.rs
@@ -5,22 +5,40 @@ use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 
 pub type MessageSizeHeader = u32;
 const MESSAGE_HEADER_SIZE: usize = std::mem::size_of::<MessageSizeHeader>();
+const KEEPALIVE_FRAME_SIZE: MessageSizeHeader = 0;
+const CLOSE_FRAME_SIZE: MessageSizeHeader = MessageSizeHeader::MAX;
+
+#[derive(Debug)]
+pub enum ReadMessageResult<M> {
+    Message(M),
+    KeepAlive,
+    Close,
+}
+
+#[derive(Debug)]
+pub enum ReadMessageToVecResult {
+    Message,
+    KeepAlive,
+    Close,
+}
 
 pub async fn read_message_opt<M: MessageEncoding, R: AsyncRead + Unpin>(
     buffer: &mut Vec<u8>,
     read: &mut R,
     progress_timeout: Duration,
     recv_timeout: Option<Duration>,
-) -> Result<Option<M>, ReadMessageError> {
+) -> Result<ReadMessageResult<M>, ReadMessageError> {
     let _assert = black_box(M::_ASSERT);
 
-    if !read_message_to_vec(buffer, read, progress_timeout, recv_timeout).await? {
-        return Ok(None);
-    }
+    match read_message_to_vec(buffer, read, progress_timeout, recv_timeout).await? {
+        ReadMessageToVecResult::Message => {}
+        ReadMessageToVecResult::KeepAlive => return Ok(ReadMessageResult::KeepAlive),
+        ReadMessageToVecResult::Close => return Ok(ReadMessageResult::Close),
+    };
 
     let mut reader = &buffer[..];
     let msg = M::read_from(&mut reader).map_err(ReadMessageError::EncodingError)?;
-    Ok(Some(msg))
+    Ok(ReadMessageResult::Message(msg))
 }
 
 pub async fn read_message_to_vec<R: AsyncRead + Unpin>(
@@ -28,7 +46,7 @@ pub async fn read_message_to_vec<R: AsyncRead + Unpin>(
     read: &mut R,
     progress_timeout: Duration,
     recv_timeout: Option<Duration>,
-) -> Result<bool, ReadMessageError> {
+) -> Result<ReadMessageToVecResult, ReadMessageError> {
     let mut len_bytes = [0u8; MESSAGE_HEADER_SIZE];
 
     if let Some(timeout) = recv_timeout {
@@ -42,11 +60,14 @@ pub async fn read_message_to_vec<R: AsyncRead + Unpin>(
             .map_err(ReadMessageError::SizeReadError)?;
     }
 
-    let msg_len = MessageSizeHeader::from_be_bytes(len_bytes) as usize;
-    if msg_len == 0 {
-        return Ok(false);
+    let msg_len = MessageSizeHeader::from_be_bytes(len_bytes);
+    match msg_len {
+        KEEPALIVE_FRAME_SIZE => return Ok(ReadMessageToVecResult::KeepAlive),
+        CLOSE_FRAME_SIZE => return Ok(ReadMessageToVecResult::Close),
+        _ => {}
     }
 
+    let msg_len = msg_len as usize;
     buffer.clear();
     buffer.resize(msg_len, 0u8);
 
@@ -62,7 +83,7 @@ pub async fn read_message_to_vec<R: AsyncRead + Unpin>(
         }
     }
 
-    Ok(true)
+    Ok(ReadMessageToVecResult::Message)
 }
 
 #[derive(Debug)]
@@ -92,7 +113,12 @@ impl From<ReadMessageError> for std::io::Error {
 }
 
 pub async fn send_zero_message<W: AsyncWrite + Unpin>(out: &mut W) -> std::io::Result<()> {
-    out.write_all(&(0 as MessageSizeHeader).to_be_bytes()).await?;
+    out.write_all(&KEEPALIVE_FRAME_SIZE.to_be_bytes()).await?;
+    out.flush().await
+}
+
+pub async fn send_close_message<W: AsyncWrite + Unpin>(out: &mut W) -> std::io::Result<()> {
+    out.write_all(&CLOSE_FRAME_SIZE.to_be_bytes()).await?;
     out.flush().await
 }
 
@@ -116,6 +142,9 @@ pub async fn send_message<M: MessageEncoding, W: AsyncWrite + Unpin>(
 
     let bytes_written = message.write_to(buffer)?;
     assert_eq!(bytes_written + MESSAGE_HEADER_SIZE, buffer.len(), "M::write_to returned incorrect number of bytes");
+    if bytes_written >= CLOSE_FRAME_SIZE as usize {
+        return Err(std::io::Error::new(std::io::ErrorKind::InvalidInput, "message too large for framing protocol"));
+    }
 
     /* if static size is known, we've already written size with MAX_SIZE var */
     if let Some(size) = M::STATIC_SIZE {
@@ -140,4 +169,50 @@ pub async fn send_message<M: MessageEncoding, W: AsyncWrite + Unpin>(
     }
 
     out.flush().await
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use tokio::io::{duplex, AsyncReadExt, AsyncWriteExt};
+
+    use super::*;
+
+    #[tokio::test]
+    async fn read_close_frame_returns_close() {
+        let (mut writer, mut reader) = duplex(64);
+        writer.write_all(&CLOSE_FRAME_SIZE.to_be_bytes()).await.unwrap();
+
+        let mut buffer = Vec::new();
+        let result = read_message_opt::<u64, _>(&mut buffer, &mut reader, Duration::from_secs(1), None)
+            .await
+            .unwrap();
+
+        assert!(matches!(result, ReadMessageResult::Close));
+    }
+
+    #[tokio::test]
+    async fn read_keepalive_frame_returns_keepalive() {
+        let (mut writer, mut reader) = duplex(64);
+        writer.write_all(&KEEPALIVE_FRAME_SIZE.to_be_bytes()).await.unwrap();
+
+        let mut buffer = Vec::new();
+        let result = read_message_opt::<u64, _>(&mut buffer, &mut reader, Duration::from_secs(1), None)
+            .await
+            .unwrap();
+
+        assert!(matches!(result, ReadMessageResult::KeepAlive));
+    }
+
+    #[tokio::test]
+    async fn send_close_message_writes_close_header() {
+        let (mut writer, mut reader) = duplex(64);
+        send_close_message(&mut writer).await.unwrap();
+
+        let mut header = [0; MESSAGE_HEADER_SIZE];
+        reader.read_exact(&mut header).await.unwrap();
+
+        assert_eq!(header, CLOSE_FRAME_SIZE.to_be_bytes());
+    }
 }


### PR DESCRIPTION
## Summary
- Introduce explicit framing for keepalive and close control messages in `message_io`.
- Treat a close frame as a terminal read event and stop read loops without forwarding a message.
- Send a close frame when the write side input closes, then shut down the underlying transport.
- Reject oversized framed messages that would collide with the close-frame sentinel.
- Add tests covering close-frame reads, keepalive reads, close-frame writes, and channel shutdown behavior.

## Testing
- `cargo test` not run.
- Added unit tests for `read_message_opt` close/keepalive handling.
- Added unit tests for `send_close_message` framing.
- Added integration-style channel tests for EOF-triggered close handling on read and write paths.